### PR TITLE
bugfix: add Tlow specifications to copernicus_land_cover.yaml

### DIFF
--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -332,7 +332,7 @@ class vprm:
 
         if not isinstance(handler, satellite_data_manager):
             logger.info(
-                "Satellite image needs to be an object of the sattelite_data_manager class"
+                "Satellite image needs to be an object of the satellite_data_manager class"
             )
             return
         bands_to_mask = []


### PR DESCRIPTION
Commits f4dc66583ee5fc169072dd3ec467a1962576080f and 07eee3b841b8aba813b73612d128dbae7acaf3e8 introduced an expectation that Tlow is defined in copernicus_land_cover.yaml.  This commit provides these Tlow values.  Fixes [#14](https://github.com/tglauch/pyVPRM/issues/14).

The Tlow values themselves are adapted from Mahadevan et al (2008) table 2.

REFERENCES

Mahadevan, P., Wofsy, S. C., Matross, D. M., Xiao, X., Dunn, A. L., Lin, J. C., et al. (2008). A satellite-based biosphere parameterization for net ecosystem CO2 exchange: Vegetation photosynthesis and respiration model (VPRM). Global Biogeochemical Cycles, 22, GB2005. doi:10.1029/2006GB002735