### PR TITLE
implement antimerdian-safe CRS transformations and reprojections

### DIFF
--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -614,9 +614,13 @@ class vprm:
                     )
                     src_grid.to_netcdf(src_temp_path)
                     ds_out.to_netcdf(dest_temp_path)
-                    exec_str = "ESMF_RegridWeightGen --source {} --destination {} --weight {} -m conserve -r --netcdf4 –src_regional –dest_regional ".format(
-                        src_temp_path, dest_temp_path, regridder_save_path
-                    )
+                    logger.debug(f"wrote source regridder: {src_temp_path}")
+                    logger.debug(f"wrote dest regridder: {dest_temp_path}")
+                    exec_str = (
+                        "ESMF_RegridWeightGen --source {} --destination {} "
+                        "--weight {} -m conserve -r --netcdf4 --src_regional"
+                        " --dest_regional --ignore_unmapped"
+                    ).format(src_temp_path, dest_temp_path, regridder_save_path)
                     if mpi is True:
                         exec_str = "mpirun -np {} ".format(n_cpus) + exec_str
                     if not logs:

--- a/pyVPRM/lib/reproject_fiona.py
+++ b/pyVPRM/lib/reproject_fiona.py
@@ -1,0 +1,64 @@
+"""antimeridian-aware geopandas GeoDataFrame reprojection tool using fiona
+
+This is an adaptation of this example from the geopandas documentation:
+https://geopandas.org/en/stable/docs/user_guide/reproject_fiona.html#fiona-example
+
+The main user-level function is transform_geodataframe(). Helper functions
+crs_to_fiona() and base_transform() are not expected to be called by end-users.
+"""
+
+from functools import partial
+
+import fiona
+import geopandas as gpd
+from fiona.transform import transform_geom
+from packaging import version
+from pyproj import CRS
+from pyproj.enums import WktVersion
+from shapely.geometry import mapping, shape
+
+
+# set up Fiona transformer
+def crs_to_fiona(proj_crs):
+    """translate a CRS definition to a format fiona can understand
+
+    from https://geopandas.org/en/stable/docs/user_guide/reproject_fiona.html#fiona-example
+
+    helper function for transform_geodataframe()
+    """
+    proj_crs = CRS.from_user_input(proj_crs)
+    if version.parse(fiona.__gdal_version__) < version.parse("3.0.0"):
+        fio_crs = proj_crs.to_wkt(WktVersion.WKT1_GDAL)
+    else:
+        # GDAL 3+ can use WKT2
+        fio_crs = proj_crs.to_wkt()
+    return fio_crs
+
+
+def base_transformer(geom, src_crs, dst_crs):
+    """transform a geometry from from one CRS to another
+
+    from https://geopandas.org/en/stable/docs/user_guide/reproject_fiona.html#fiona-example
+
+    helper function for transform_geodataframe()
+    """
+    return shape(
+        transform_geom(
+            src_crs=crs_to_fiona(src_crs),
+            dst_crs=crs_to_fiona(dst_crs),
+            geom=mapping(geom),
+            antimeridian_cutting=True,
+            antimeridian_offset=100.0,
+        )
+    )
+
+
+def transform_geodataframe(
+    gdf: gpd.GeoDataFrame, src_crs: str, dst_crs: str
+) -> gpd.GeoDataFrame:
+    forward_transformer = partial(base_transformer, src_crs=gdf.crs, dst_crs=dst_crs)
+    with fiona.Env(OGR_ENABLE_PARTIAL_REPROJECTION="YES"):
+        gdf_reproj = gdf.set_geometry(
+            gdf.geometry.apply(forward_transformer), crs=dst_crs
+        )
+    return gdf_reproj

--- a/pyVPRM/meteorologies/era5_monthly_xr.py
+++ b/pyVPRM/meteorologies/era5_monthly_xr.py
@@ -13,9 +13,30 @@ import datetime
 from pyVPRM.meteorologies.met_base_class import met_data_handler_base
 from loguru import logger
 
+
 class met_data_handler(met_data_handler_base):
 
-    def __init__(self, year, month, day, hour, bpath, mpi=False, keys=[]):
+    def __init__(
+        self,
+        year,
+        month,
+        day,
+        hour,
+        bpath,
+        fname_fmt_str="{year}_{month}.nc",
+        mpi=False,
+        keys=[],
+    ):
+        """construct a met_data_handler instance for monthly ERA5 data
+
+        ARGS:
+        fname_fmt_str (str): specifies the file name syntax. Must have
+           placeholders for year and month.
+           valid examples:
+              '{year}_{month}.nc'
+              'ERA5_2mT_msdswrf_ssrd_NZ_{year:04d}_{month:02d}.nc'
+        """
+
         super().__init__()
         # Init with year, month, day, hour and the required era5 keys as given in the
         #  keys_dict above
@@ -23,6 +44,7 @@ class met_data_handler(met_data_handler_base):
         self.this_month = 0
         self.this_year = 0
         self.bpath = bpath
+        self.fname_fmt_str = fname_fmt_str
         self.ds_in_t = None
         self.regridder = None
         self.mpi = mpi
@@ -109,7 +131,10 @@ class met_data_handler(met_data_handler_base):
     def _init_data_for_day(self):
         if (self.this_month != self.month) | (self.this_year != self.year):
             self.data = xr.open_dataset(
-                os.path.join(self.bpath, "{}_{}.nc".format(self.year, self.month))
+                os.path.join(
+                    self.bpath,
+                    self.fname_fmt_str.format(year=self.year, month=self.month),
+                )
             )
             self.this_month = self.month
             self.this_year = self.year

--- a/pyVPRM/meteorologies/era5_monthly_xr.py
+++ b/pyVPRM/meteorologies/era5_monthly_xr.py
@@ -141,16 +141,31 @@ class met_data_handler(met_data_handler_base):
             self.in_era5_grid = True
 
         if self.ds_in_t is None:
+            # determine whether data uses "lat" or "latitude"
+            if "lat" in self.data.coords:
+                latvar = "lat"
+            elif "latitude" in self.data.coords:
+                latvar = "latitude"
+            else:
+                raise ValueError("cannot locate 'lat' or 'latitude' values")
+            # determine whether data uses "lon" or "longitude"
+            if "lon" in self.data.coords:
+                lonvar = "lon"
+            elif "longitude" in self.data.coords:
+                lonvar = "longitude"
+            else:
+                raise ValueError("cannot locate 'lon' or 'longitude' values")
+
             self.ds_in_t = xr.Dataset(
                 {
                     "lat": (
                         ["lat"],
-                        self.data["lat"].values,
+                        self.data[latvar].values,
                         {"units": "degrees_north"},
                     ),
                     "lon": (
                         ["lon"],
-                        self.data["lon"].values,
+                        self.data[lonvar].values,
                         {"units": "degrees_east"},
                     ),
                 }

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "requests",
         "statsmodels",
         "loguru",
+        "fiona",
     ],
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
- implement coordinate reference system (CRS) transformations that correctly handle polygons that cross the 180th meridian.

  - pyVPRM.lib.reproject_fiona.transform_geodataframe() uses a reprojection toolbox that handles the 180th meridian correctly.  It implements the reprojection based on tools in the fiona package as described in the [geopandas documentation](https://geopandas.org/en/stable/docs/user_guide/reproject_fiona.html#re-projecting-using-gdal-with-rasterio-and-fiona).

  - This fiona method is underpinned by [GDAL](https://gdal.org). It correctly handles polygons that cross the 180th meridian. geopandas.GeoDataFrame.to_crs() does not handle this situation correctly.

  - All of the [MODIS sinusoidal tiles](https://modis-land.gsfc.nasa.gov/MODLAND_grid.html) along the edges of the sinusoidal projection will fail to produce a correct land cover map (LCM) crop using the to_crs() method.

- Also use "--ignore-unmapped" flag for ESMF_RegridWeightGen

  Toward the "edges" of the projection the MODIS sinusoidal projection results in MODIS tiles that, relative to a longitude-latitude rectangle (such as ERA5 tiles), appear skewed into long parallelograms with a relatively small angle in two of the four corners. Because we are using the MODIS tiles as the destination grid to regrid the meteorology data this can result in an area of interest that is a sub-area within a single ERA5 tile where there are two triangles on the east and west ends of the ERA5 tile that do not map onto the MODIS tile we are regridding to. Without the "--ignore-unmapped" flag ESMF_RegridWeightGen fails with an error message in these cases.

  Setting the --ignore-unmapped allows the regrid to proceed with NaNs placed in the destination where there are no overlapping source pixels.

Please consider https://github.com/tglauch/pyVPRM/pull/16 and https://github.com/tglauch/pyVPRM/pull/17 first.  This PR contains their commits as well as the 180th meridian commits described above.