### PR TITLE
bugfix: download of MODIS data fails when credentials contain special characters

### DIFF
--- a/pyVPRM/sat_managers/base_manager.py
+++ b/pyVPRM/sat_managers/base_manager.py
@@ -399,7 +399,7 @@ class earthdata(satellite_data_manager):
             logger.info("Download {}: {}".format(d, cde))
             for c in cde:
                 os.system(
-                    "wget --user {} --password {} --directory-prefix {} {} ".format(
+                    "wget --user '{}' --password '{}' --directory-prefix '{}' '{}' ".format(
                         modisDown.user,
                         modisDown.password,
                         modisDown.writeFilePath,


### PR DESCRIPTION
Fixes a bug where wget will fail when any of the credentials contain special character ";".

First solved by putting the wget inputs within single-quotations, then further expanded by using subprocess - it should handle any special characters in the future.