### PR TITLE
add LAADS DAAC downloader for MODIS/MAIAC products

### DIFF
--- a/pyVPRM/.gitignore
+++ b/pyVPRM/.gitignore
@@ -1,0 +1,2 @@
+token*.txt
+sat_managers/token*.txt

--- a/pyVPRM/.gitignore
+++ b/pyVPRM/.gitignore
@@ -1,2 +1,4 @@
 token*.txt
 sat_managers/token*.txt
+token*.txt
+sat_managers/token*.txt

--- a/pyVPRM/sat_managers/README_MCD19A1_downloader.md
+++ b/pyVPRM/sat_managers/README_MCD19A1_downloader.md
@@ -1,0 +1,22 @@
+# MCD19A1 MAIAC Downloader
+
+Download MODIS products from NASA LAADS DAAC using SLURM.
+
+## Files
+- lads_downloader.py: main downloader class
+- product_registry.py: product catalog  
+- gen_tasks.py: generates task list
+- download_modis_new_parallel.py: parallel download script
+- download_modis_new_submit.sh: SLURM submit script
+
+## Usage
+1. Edit config.yaml (product, dates, tiles)
+2. Create token.txt (NASA Earthdata token)
+3. Run: export N=$(python gen_tasks.py)
+4. Run: sbatch --array=1-${N}%20 download_modis_new_submit.sh
+
+## Supported products
+- MCD19A1.061: MAIAC daily 500m
+- MCD43A4.061: BRDF-corrected daily 500m
+- MOD09A1.061: Terra 8-day 500m
+- MOD13A1.061: Terra 16-day 500m

--- a/pyVPRM/sat_managers/download_modis_new_parallel.py
+++ b/pyVPRM/sat_managers/download_modis_new_parallel.py
@@ -1,0 +1,38 @@
+import argparse, os, time
+import os, time, sys
+import yaml
+from datetime import datetime, timedelta, date
+sys.path.append("/work/mj0143/b301108/pyVPRM/pyVPRM")
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from sat_managers.lads_downloader import EarthdataLAADS
+
+p = argparse.ArgumentParser()
+p.add_argument("--tile", required=True)
+p.add_argument("--year", type=int, required=True)
+p.add_argument("--token", required=True)
+p.add_argument("--output", required=True)
+p.add_argument("--product", required=True)
+p.add_argument("--workers", type=int, default=4)
+args = p.parse_args()
+
+dl = EarthdataLAADS(product=args.product)
+
+# build list of DOYs for that year (46 DOYs) using your class helper:
+start = datetime(args.year,1,1)
+end = datetime(args.year,12,31)
+doys = [int(doy) for dt, doy in dl._generate_modis_doys(start,end)]
+
+def job_for_doy(doy):
+    return dl.download_doy(year=args.year, doy=doy, savepath=os.path.join(args.output,str(args.year)),
+                           token=args.token, tile=args.tile, resume=True)
+
+with ThreadPoolExecutor(max_workers=args.workers) as ex:
+    futures = { ex.submit(job_for_doy, doy): doy for doy in doys }
+    for fut in as_completed(futures):
+        doy = futures[fut]
+        try:
+            files = fut.result()
+            # write per-doy success to a local job file or stdout
+        except Exception as e:
+            # retry or log fail
+            pass

--- a/pyVPRM/sat_managers/download_modis_new_submit.sh
+++ b/pyVPRM/sat_managers/download_modis_new_submit.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#SBATCH --account=mj0143
+#SBATCH --job-name=modis_dl
+#SBATCH --partition=compute
+#SBATCH --output=logs/modis_%A_%a.out
+#SBATCH --error=logs/modis_%A_%a.err
+#SBATCH --time=08:00:00
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=6
+#SBATCH --mem=24G
+
+source /sw/spack-levante/jupyterhub/jupyterhub/etc/profile.d/conda.sh
+conda activate /work/mj0143/b301108/conda/envs/pyvprm_env
+
+cd /work/mj0143/b301108/pyVPRM/pyVPRM/sat_managers
+export PYTHONPATH=/work/mj0143/b301108/pyVPRM/pyVPRM:$PYTHONPATH
+
+OUTPUT_DIR=/work/mj0143/b301108/pyVPRM/pyVPRM/sat_managers/tiles_MCD43A4_all/
+TASKFILE=tasklist_tile_year.json
+IDX=$((SLURM_ARRAY_TASK_ID - 1))
+
+TILE=$(jq -r ".[$IDX].tile" "$TASKFILE")
+YEAR=$(jq -r ".[$IDX].year" "$TASKFILE")
+PRODUCT=$(jq -r ".[$IDX].product" "$TASKFILE")
+
+TOKEN=$(cat token.txt)
+
+python download_modis_new_parallel.py \
+    --tile "${TILE}" --year "${YEAR}" --token "${TOKEN}" \
+    --output "${OUTPUT_DIR}" --product "${PRODUCT}" \
+    --workers ${SLURM_CPUS_PER_TASK}

--- a/pyVPRM/sat_managers/gen_tasks.py
+++ b/pyVPRM/sat_managers/gen_tasks.py
@@ -1,0 +1,34 @@
+# Generates tile-year tasks
+
+import json, yaml
+import sys
+import os
+from datetime import datetime
+sys.path.append("/work/mj0143/b301108/pyVPRM/pyVPRM")
+from sat_managers.lads_downloader import EarthdataLAADS
+
+def generate_tile_year_tasks(config):
+    start = datetime.fromisoformat(config["start_date"])
+    end   = datetime.fromisoformat(config["end_date"])
+    tiles = config["tiles"]
+    product = config["product"]
+
+    dl = EarthdataLAADS(product=product)
+    # gather unique years in range
+    years = sorted({d.year for d, _ in [ (dt, None) for dt,_ in dl._generate_modis_doys(start,end) ]})
+    tasks = []
+    for year in years:
+        for tile in tiles:
+            tasks.append({"year": year, "tile": tile, "product": product})
+    return tasks
+
+if __name__ == "__main__":
+    with open("config.yaml") as f:
+        config = yaml.safe_load(f)
+    tasks = generate_tile_year_tasks(config)
+    with open("tasklist_tile_year.json","w") as fo:
+        json.dump(tasks, fo, indent=2)
+    #print("Wrote tasklist_tile_year.json, total:", len(tasks))
+    # Set environment variable N for current shell session
+    os.environ["N"] = str(len(tasks))
+    print(len(tasks))

--- a/pyVPRM/sat_managers/lads_downloader.py
+++ b/pyVPRM/sat_managers/lads_downloader.py
@@ -1,16 +1,4 @@
-# Script name: lads_downloader.py
-# Author:      S. Botía
-# Created:     2025-12-09
-# Last update: 2025-12-14
-# Description: This script downloads MODIS products hosted by the NASA LAADS DAAC. The EarthdataLAADS class provides helper functions to list and download MODIS HDF files for specific tiles and 8-day composite dates using Earthdata Login bearer-token authentication. The implementation is designed to: Integrate with the existing pyVPRM satellite data manager interface, support MODIS 8-day composite products (e.g. MOD09A1), be compatible with SLURM job arrays and use wget for downloads. 
-# Requirements:
-#      - Python ≥ 3.8
-#      - Python packages: requests, loguru, 
-#      - System tools: wget (available on PATH)
-#      - Project dependencies: pyVPRM (for satellite_data_manager base class)
-# Authentication:
-#     - Valid NASA Earthdata Login bearer token with access to LAADS DAAC: https://ladsweb.modaps.eosdis.nasa.gov
-
+# lads_downloader.py
 import os
 import re
 import time
@@ -19,348 +7,255 @@ import requests
 from datetime import timedelta, datetime
 from loguru import logger
 from pyVPRM.sat_managers.base_manager import satellite_data_manager
+from pyVPRM.sat_managers.product_registry import get_product_info   # ← NUEVO
 
 
 class EarthdataLAADS(satellite_data_manager):
     """
-    Downloader for MODIS products hosted by NASA LAADS DAAC using Earthdata Login bearer-token authentication.
+    Downloader for MODIS/VIIRS products hosted by NASA LAADS DAAC.
+
+    Supports:
+      - Daily products      (e.g. MCD19A1 MAIAC, MOD09GA)
+      - 8-day composites    (e.g. MOD09A1, MYD09A1)
+      - 16-day composites   (e.g. MOD13A1)
+      - Yearly products     (e.g. MCD12Q1)
+
+    The product cadence is resolved automatically from product_registry.py.
+    To add support for a new product, simply add it to the registry.
+
+    Parameters
+    ----------
+    product : str
+        MODIS product + collection, e.g. ``"MCD19A1.061"``.
     """
-    
-    def __init__(self, datapath=None, sat_image_path=None, sat_img=None, product="MOD09A1.061"):
-        """
-        Initialize the EarthdataLAADS downloader.
-        Parameters
-        ----------
-        datapath : str, optional
-            Base path for downloaded data (handled by satellite_data_manager).
-        sat_image_path : str, optional
-            Path for satellite imagery (handled by satellite_data_manager).
-        sat_img : optional
-            Satellite image metadata (handled by satellite_data_manager).
-        product : str
-            MODIS product identifier including collection
-            (e.g. "MOD09A1.061").
-        """
+
+    def __init__(self, datapath=None, sat_image_path=None,
+                 sat_img=None, product="MOD09A1.061"):
         super().__init__(datapath, sat_image_path, sat_img)
         self.product = product
 
+        product_name, _ = self._parse_product_collection()
+        info = get_product_info(product_name)          # ← consulta el registry
+        self._cadence  = info["cadence"]               # "daily"|"8day"|"16day"|"yearly"
+        self._file_ext = info["file_ext"]              # ".hdf"
+        self._is_daily = self._cadence == "daily"      # shortcut booleano
+
+        logger.info(
+            f"EarthdataLAADS initialized | product={self.product} "
+            f"| cadence={self._cadence}"
+        )
+
+    # ─────────────────────────────────────────────────────────────────
+    # Parsing helpers
+    # ─────────────────────────────────────────────────────────────────
+
     def _parse_product_collection(self):
-        """
-        Parse the MODIS product string into product name and collection.
-        Returns
-        -------
-        product_name : str
-            MODIS product short name.
-        collection : str
-            MODIS collection number as string.
-        """
+        """Split 'MCD19A1.061' → ('MCD19A1', '61')."""
+        parts = str(self.product).split(".")
+        product_name = parts[0]
         try:
-            parts = str(self.product).split(".")
-            product_name = parts[0]
             collection = str(int(parts[1])) if len(parts) > 1 else "61"
-        except Exception:
-            product_name = str(self.product)
+        except ValueError:
             collection = "61"
         return product_name, collection
 
-    def _init_downloader(self,dest,date,delta,username,
-                         lonlat=None,pwd=None,token=None,
-                         jpg=False, enddate=None, hv=None,):
+    # ─────────────────────────────────────────────────────────────────
+    # Date generation  ← lógica central que soporta todos los cadences
+    # ─────────────────────────────────────────────────────────────────
+
+    def _generate_modis_doys(self, start, end):
         """
-        Initialize a downloader config dictionary. This method has the same structure as the interface of 
-        older Earthdata-based downloaders used in pyVPRM for compatibility.
-        Parameters
-        ----------
-        dest : str
-            Destination directory for downloaded files.
-        date : datetime
-            Start date for download.
-        delta : timedelta
-            Time step (unused here, kept for compatibility).
-        username : str
-            Earthdata username (not used; token authentication preferred).
-        lonlat : tuple(float, float), optional
-            Longitude/latitude pair used to compute MODIS tile.
-        pwd : str, optional
-            Password (unused; token authentication preferred).
-        token : str, optional
-            Earthdata bearer token.
-        jpg : bool
-            Placeholder for image download support (not used).
-        enddate : datetime, optional
-            End date for downloads.
-        hv : tuple(int, int), optional
-            MODIS tile indices (h, v).
-        Returns
-        -------
-        dict
-            Dictionary describing downloader configuration.
+        Yield ``(datetime, doy_str)`` for every valid acquisition date
+        in ``[start, end]``, according to the product cadence.
+
+        Cadence rules
+        -------------
+        daily  → every calendar day
+        8day   → (doy - 1) % 8  == 0
+        16day  → (doy - 1) % 16 == 0
+        yearly → DOY 001 only
         """
-        
+        cadence_map = {
+            "daily":  1,
+            "8day":   8,
+            "16day":  16,
+            "yearly": 365,   # handled separately below
+        }
+
+        cur = start
+        while cur <= end:
+            doy = cur.timetuple().tm_yday
+
+            if self._cadence == "daily":
+                yield cur, f"{doy:03d}"
+
+            elif self._cadence == "8day":
+                if (doy - 1) % 8 == 0:
+                    yield cur, f"{doy:03d}"
+
+            elif self._cadence == "16day":
+                if (doy - 1) % 16 == 0:
+                    yield cur, f"{doy:03d}"
+
+            elif self._cadence == "yearly":
+                if doy == 1:
+                    yield cur, f"{doy:03d}"
+
+            cur += timedelta(days=1)
+
+    # ─────────────────────────────────────────────────────────────────
+    # URL helpers
+    # ─────────────────────────────────────────────────────────────────
+
+    def build_doy_url(self, year, doy):
+        product_name, collection = self._parse_product_collection()
+        return (
+            f"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/"
+            f"{collection}/{product_name}/{year}/{doy:03d}/"
+        )
+
+    def _list_dir(self, dir_url, token=None, timeout=30):
+        headers = {}
+        if token:
+            headers["Authorization"] = (
+                token if token.startswith("Bearer") else f"Bearer {token}"
+            )
+        try:
+            r = requests.get(dir_url, headers=headers, timeout=timeout)
+            if r.status_code == 200:
+                return r.text
+            logger.debug(f"_list_dir: {dir_url} → HTTP {r.status_code}")
+            return None
+        except Exception as exc:
+            logger.exception(f"_list_dir error: {exc}")
+            return None
+
+    def list_doy_directory(self, year, doy, token=None, timeout=30):
+        url = self.build_doy_url(year, int(doy))
+        logger.debug(f"Listing: {url}")
+        return self._list_dir(url, token=token, timeout=timeout)
+
+    def find_hdfs_in_html(self, html, year, doy, tile):
+        """Extract HDF filenames matching tile from HTML directory listing."""
+        if html is None:
+            return []
+        product_name, _ = self._parse_product_collection()
+        doy_str = f"{int(doy):03d}"
+        pattern = (
+            rf"{re.escape(product_name)}"
+            rf"\.A{year}{doy_str}"
+            rf"\.{re.escape(tile)}"
+            rf"\.[^\"<>\s]*?\.hdf"
+        )
+        matches = re.findall(pattern, html, re.IGNORECASE)
+        seen, unique = set(), []
+        for m in matches:
+            if m not in seen:
+                seen.add(m)
+                unique.append(m)
+        return unique
+
+    # ─────────────────────────────────────────────────────────────────
+    # Download engine
+    # ─────────────────────────────────────────────────────────────────
+
+    def _wget_download(self, url, outpath, token):
+        os.makedirs(os.path.dirname(os.path.abspath(outpath)), exist_ok=True)
+        tmp = outpath + ".part"
+        cmd = [
+            "wget", "-c",
+            "--header", f"Authorization: Bearer {token}",
+            "-O", tmp,
+            url,
+        ]
+        logger.info("wget → " + " ".join(cmd))
+        try:
+            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
+            if proc.returncode != 0:
+                logger.error(
+                    f"wget failed (rc={proc.returncode}): {proc.stderr.strip()}"
+                )
+                if os.path.exists(tmp):
+                    os.remove(tmp)
+                return False
+            os.replace(tmp, outpath)
+            return True
+        except Exception as exc:
+            logger.exception(f"_wget_download exception: {exc}")
+            if os.path.exists(tmp):
+                os.remove(tmp)
+            return False
+
+    def download_doy(self, year, doy, savepath, token=None,
+                     tile=None, resume=True, timeout=60, sleep=1):
+        """Download all HDF files for year/doy/tile."""
+        if isinstance(tile, (tuple, list)):
+            tile = f"h{int(tile[0]):02d}v{int(tile[1]):02d}"
+        if tile is None:
+            raise ValueError("tile must be provided")
+
+        doy = int(doy)
+        html = self.list_doy_directory(year, doy, token=token, timeout=timeout)
+        if html is None:
+            logger.warning(f"Directory unavailable: {self.build_doy_url(year, doy)}")
+            return []
+
+        matches = self.find_hdfs_in_html(html, year, doy, tile)
+        if not matches:
+            logger.info(f"No files found | tile={tile} {year}-{doy:03d}")
+            logger.debug(f"HTML snippet:\n{html[:800]}")
+            return []
+
+        logger.info(f"Found {len(matches)} file(s): {matches}")
+        downloaded = []
+        base_url = self.build_doy_url(year, doy)
+
+        for fname in matches:
+            outpath = os.path.join(savepath, fname)
+            if os.path.exists(outpath):
+                logger.info(f"Skipping existing: {outpath}")
+                downloaded.append(outpath)
+                continue
+            ok = self._wget_download(base_url + fname, outpath, token=token)
+            if ok:
+                logger.success(f"Saved → {outpath}")
+                downloaded.append(outpath)
+            else:
+                logger.error(f"Failed: {base_url + fname}")
+            time.sleep(sleep)
+
+        return downloaded
+
+    # ─────────────────────────────────────────────────────────────────
+    # pyVPRM compatibility shim
+    # ─────────────────────────────────────────────────────────────────
+
+    def _init_downloader(self, dest, date, delta, username,
+                         lonlat=None, pwd=None, token=None,
+                         jpg=False, enddate=None, hv=None):
         if hv is not None:
             h, v = hv
         elif lonlat is not None:
-            # Convert lat/lon to MODIS tile indices
             h, v = self.lat_lon_to_modis(lonlat[1], lonlat[0])
         else:
             raise ValueError("Either hv or lonlat must be provided")
-
-        tiles = f"h{int(h):02d}v{int(v):02d}"
 
         if enddate is None:
             enddate = date + timedelta(days=365)
 
         product_name, collection = self._parse_product_collection()
-        base_url = f"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/{collection}/{product_name}/"
-
-        downloader = {"writeFilePath": dest,
-                      "tiles": tiles,
-                      "product": self.product,
-                      "product_name": product_name,
-                      "collection": collection,
-                      "token": token,
-                      "username": username,
-                      "password": pwd,
-                      "delta": delta,
-                      "start_date": date,
-                      "end_date": enddate,
-                      "url": base_url,
-                     }
-        return downloader
-
-    def _generate_modis_doys(self, start, end):
-        """
-        Generate valid MODIS 8-day composite dates within a time range.
-        MODIS 8-day products are defined such that:
-        (DOY - 1) % 8 == 0
-        Parameters
-        ----------
-        start : datetime
-            Start date.
-        end : datetime
-            End date.
-        Yields
-        ------
-        datetime
-            Date corresponding to the composite.
-        str
-            Day-of-year (DOY) formatted as zero-padded string.
-        Yield datetime and doy string for MODIS 8-day composites inside [start,end].
-        """
-        
-        cur = start
-        while cur <= end:
-            doy = cur.timetuple().tm_yday
-            if (doy - 1) % 8 == 0:
-                yield cur, f"{doy:03d}"
-            cur += timedelta(days=1)
-
-    def _list_dir(self, dir_url, token=None, timeout=30):
-        """
-        Retrieve the HTML directory listing from a LAADS directory.
-
-        Parameters
-        ----------
-        dir_url : str
-            URL of the LAADS directory to query.
-        token : str, optional
-            Earthdata bearer token.
-        timeout : int
-            HTTP request timeout in seconds.
-        Returns
-        -------
-        str or None
-            HTML content if successful, otherwise None.
-        """
-        headers = {}
-        if token:
-            headers["Authorization"] = token if token.startswith("Bearer") else f"Bearer {token}"
-        try:
-            r = requests.get(dir_url, headers=headers, timeout=timeout)
-            if r.status_code == 200:
-                return r.text
-            else:
-                logger.debug(f"_list_dir: {dir_url} returned {r.status_code}")
-                return None
-        except Exception as e:
-            logger.exception(f"_list_dir error for {dir_url}: {e}")
-            return None
-
-
-    def list_doy_directory(self, year, doy, token=None, timeout=30):
-        """
-        Construct and query the LAADS directory for a specific year and DOY.
-        Parameters
-        ----------
-        year : int
-            Calendar year.
-        doy : int
-            Day of year.
-        token : str, optional
-            Earthdata bearer token.
-            
-        Returns
-        -------
-        str or None
-            HTML directory listing.
-        """
-        
-        product_name, collection = self._parse_product_collection()
-        dir_url = f"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/{collection}/{product_name}/{year}/{doy:03d}/"
-        return self._list_dir(dir_url, token=token, timeout=timeout)
-
-
-    def _wget_download(self, url, outpath, token):
-        """
-        Download a file using wget with Earthdata authentication.
-        Uses a temporary '.part' file in case the download needs to be restarted. This avoids corrupted outputs.
-        Parameters
-        ----------
-        url : str
-            File URL.
-        outpath : str
-            Destination file path.
-        token : str
-            Earthdata bearer token.
-        Returns
-        -------
-        bool
-            True if download succeeded, False otherwise.
-        """
-        # ensure parent dir exists
-        os.makedirs(os.path.dirname(outpath) or ".", exist_ok=True)
-        tmp = outpath + ".part"
-        # build command: use -q for quiet or remove to show progress
-        cmd = ["wget",
-               "-c",
-               "--header", 
-               f"Authorization: Bearer {token}",
-               "-O", 
-               tmp,
-               url]
-
-        logger.info("WGET CMD: " + " ".join(cmd))
-
-        try:
-            proc = subprocess.run(cmd, check=False, capture_output=True, text=True)
-            if proc.returncode != 0:
-                logger.error(f"wget failed (rc={proc.returncode}) for {url}: {proc.stderr.strip()}")
-                # cleanup partial if exists
-                try:
-                    if os.path.exists(tmp):
-                        os.remove(tmp)
-                except Exception:
-                    pass
-                return False
-            # move tmp -> final
-            os.replace(tmp, outpath)
-            return True
-            
-        except Exception as e:
-            logger.exception(f"_wget_download exception for {url}: {e}")
-            try:
-                if os.path.exists(tmp):
-                    os.remove(tmp)
-            except Exception:
-                pass
-            return False
-
-    def download_doy(self, year, doy, savepath, token=None, tile=None, resume=True, timeout=60):
-        """
-        Download all MODIS HDF files for a given year, DOY, and tile.
-        Parameters
-        ----------
-        year : int
-            Calendar year.
-        doy : int
-            Day of year.
-        savepath : str
-            Output directory.
-        token : str
-            Earthdata bearer token.
-        tile : str or tuple
-            MODIS tile identifier (e.g. "h09v09" or (9,9)).
-        resume : bool
-            Allow resuming partial downloads (handled by wget).
-        timeout : int
-            Directory listing timeout.
-        Returns
-        -------
-        list[str]
-            List of downloaded (or existing) file paths.
-        """
-        
-        # normalize tile
-        if isinstance(tile, (tuple, list)):
-            tile = f"h{int(tile[0]):02d}v{int(tile[1]):02d}"
-        if tile is None:
-            raise ValueError("tile must be provided to download_doy (e.g. 'h09v09' or (9,9))")
-
-        html = self.list_doy_directory(year, doy, token=token)
-        # html = self.list_doy_directory(year, doy, token=token, timeout=timeout)
-        if html is None:
-            logger.info(f"Directory not available or empty for {year} DOY {int(doy):03d}")
-            return []
-
-        matches = self.find_hdfs_in_html(html, year, doy, tile)
-        if not matches:
-            logger.info(f"No HDFs found for tile {tile} on {year}-{int(doy):03d}")
-            return []
-
-        downloaded = []
-        for fname in matches:
-            #outdir = os.path.join(savepath, str(year))
-            outdir = savepath
-            outpath = os.path.join(outdir, fname)
-            if os.path.exists(outpath):
-                logger.info(f"Skipping existing file: {outpath}")
-                downloaded.append(outpath)
-                continue
-
-            file_url = self.build_doy_url(year, doy) + fname
-            logger.info(f"Downloading {file_url} -> {outpath}")
-            ok = self._wget_download(file_url, outpath, token=token)
-            if ok:
-                downloaded.append(outpath)
-            else:
-                logger.error(f"Failed to download {file_url}")
-
-            time.sleep(1)  # pause
-
-        return downloaded
-        
-    def build_doy_url(self, year, doy):
-        """
-        Return the base URL for a given year and DOY, e.g.,
-        https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/61/MOD09A1/YYYY/DDD/
-        """
-        product_name, collection = self._parse_product_collection()
-        return f"https://ladsweb.modaps.eosdis.nasa.gov/archive/allData/{collection}/{product_name}/{year}/{doy:03d}/"
-
-    def find_hdfs_in_html(self, html, year, doy, tile):
-        """
-        Extract MODIS HDF filenames for a specific tile from a directory listing.
-        Parameters
-        ----------
-        html : str
-            HTML directory listing.
-        year : int
-            Calendar year.
-        doy : int
-            Day of year.
-        tile : str
-            MODIS tile identifier.
-        Returns
-        -------
-        list[str]
-            List of matching HDF filenames.
-        """
-        
-        if html is None:
-            return []
-    
-        # Build regex pattern
-        product_name, _ = self._parse_product_collection()
-        pattern = rf"{product_name}\.A{year}{doy:03d}\.{tile}\..*?\.hdf"
-        matches = re.findall(pattern, html)
-        return matches
+        return {
+            "writeFilePath": dest,
+            "tiles":         f"h{int(h):02d}v{int(v):02d}",
+            "product":       self.product,
+            "product_name":  product_name,
+            "collection":    collection,
+            "cadence":       self._cadence,      # ← nuevo campo útil
+            "token":         token,
+            "username":      username,
+            "password":      pwd,
+            "delta":         delta,
+            "start_date":    date,
+            "end_date":      enddate,
+            "url":           self.build_doy_url(date.year, date.timetuple().tm_yday),
+        }

--- a/pyVPRM/sat_managers/product_registry.py
+++ b/pyVPRM/sat_managers/product_registry.py
@@ -1,0 +1,120 @@
+# product_registry.py
+# Description: Registry of supported MODIS/VIIRS products for the LAADS downloader.
+#              Add new products here without touching the downloader logic.
+#
+# cadence options:
+#   "daily"  → one file per day      (e.g. MCD19A1, MOD09GA)
+#   "8day"   → 8-day composites      (e.g. MOD09A1, MYD09A1)
+#   "16day"  → 16-day composites     (e.g. MOD13A1)
+#
+# file_ext: extension to look for in directory listing
+# notes:    human-readable description (optional, for documentation)
+
+PRODUCT_REGISTRY = {
+    # ── MAIAC (daily) ────────────────────────────────────────────────
+    "MCD19A1": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "MAIAC Land Surface BRF and Albedo",
+    },
+    "MCD19A2": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "MAIAC Aerosol Optical Depth",
+    },
+
+    # ── Surface Reflectance daily ─────────────────────────────────────
+    "MOD09GA": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "Terra Surface Reflectance Daily L2G",
+    },
+    "MYD09GA": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "Aqua Surface Reflectance Daily L2G",
+    },
+
+    # ── Aerosol daily ─────────────────────────────────────────────────
+    "MOD04_L2": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "Terra Aerosol 5-Min L2 Swath",
+    },
+    "MYD04_L2": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "Aqua Aerosol 5-Min L2 Swath",
+    },
+
+    # ── Surface Reflectance 8-day ─────────────────────────────────────
+    "MOD09A1": {
+        "cadence":  "8day",
+        "file_ext": ".hdf",
+        "notes":    "Terra Surface Reflectance 8-Day L3 500m",
+    },
+    "MYD09A1": {
+        "cadence":  "8day",
+        "file_ext": ".hdf",
+        "notes":    "Aqua Surface Reflectance 8-Day L3 500m",
+    },
+
+    # ── Vegetation Index 16-day ───────────────────────────────────────
+    "MOD13A1": {
+        "cadence":  "16day",
+        "file_ext": ".hdf",
+        "notes":    "Terra Vegetation Indices 16-Day L3 500m",
+    },
+    "MYD13A1": {
+        "cadence":  "16day",
+        "file_ext": ".hdf",
+        "notes":    "Aqua Vegetation Indices 16-Day L3 500m",
+    },
+    "MOD13A2": {
+        "cadence":  "16day",
+        "file_ext": ".hdf",
+        "notes":    "Terra Vegetation Indices 16-Day L3 1km",
+    },
+
+    # ── Land Cover yearly ─────────────────────────────────────────────
+    "MCD12Q1": {
+        "cadence":  "yearly",
+        "file_ext": ".hdf",
+        "notes":    "MODIS Land Cover Type Yearly L3",
+    },
+}
+
+
+def get_product_info(product_name: str) -> dict:
+    """
+    Return registry entry for product_name, or a safe default.
+
+    Parameters
+    ----------
+    product_name : str
+        Short product name, e.g. 'MCD19A1'.
+
+    Returns
+    -------
+    dict with keys: cadence, file_ext, notes
+    """
+    if product_name in PRODUCT_REGISTRY:
+        return PRODUCT_REGISTRY[product_name]
+
+    # Unknown product → warn and assume 8-day (conservative default)
+    import warnings
+    warnings.warn(
+        f"Product '{product_name}' not found in PRODUCT_REGISTRY. "
+        f"Assuming 8-day cadence. Add it to product_registry.py if needed.",
+        UserWarning,
+        stacklevel=2,
+    )
+    return {"cadence": "8day", "file_ext": ".hdf", "notes": "unknown"}
+
+
+def list_products() -> None:
+    """Print a human-readable table of all registered products."""
+    print(f"{'Product':<12} {'Cadence':<8} {'Description'}")
+    print("-" * 55)
+    for name, info in PRODUCT_REGISTRY.items():
+        print(f"{name:<12} {info['cadence']:<8} {info['notes']}")

--- a/pyVPRM/sat_managers/product_registry.py
+++ b/pyVPRM/sat_managers/product_registry.py
@@ -1,14 +1,5 @@
 # product_registry.py
-# Description: Registry of supported MODIS/VIIRS products for the LAADS downloader.
-#              Add new products here without touching the downloader logic.
-#
-# cadence options:
-#   "daily"  → one file per day      (e.g. MCD19A1, MOD09GA)
-#   "8day"   → 8-day composites      (e.g. MOD09A1, MYD09A1)
-#   "16day"  → 16-day composites     (e.g. MOD13A1)
-#
-# file_ext: extension to look for in directory listing
-# notes:    human-readable description (optional, for documentation)
+# Registry of supported MODIS/VIIRS products for the LAADS downloader.
 
 PRODUCT_REGISTRY = {
     # ── MAIAC (daily) ────────────────────────────────────────────────
@@ -22,18 +13,6 @@ PRODUCT_REGISTRY = {
         "file_ext": ".hdf",
         "notes":    "MAIAC Aerosol Optical Depth",
     },
-    "MCD43A4": {
-        "cadence":  "daily",        #  cambiar de 16day a daily
-        "file_ext": ".hdf",
-        "notes":    "MODIS BRDF-Adjusted Reflectance Daily 500m (nadir + SZA=45°) Collection 061",
-    },
-    "MCD43C4": {
-        "cadence":  "daily",
-        "file_ext": ".hdf",
-        "notes":    "MODIS BRDF-Adjusted Reflectance Daily 0.05deg CMG global (nadir + SZA=45°)",
-        "global":   True,   # ← sin tiles
-    },
-
     # ── Surface Reflectance daily ─────────────────────────────────────
     "MOD09GA": {
         "cadence":  "daily",
@@ -45,7 +24,6 @@ PRODUCT_REGISTRY = {
         "file_ext": ".hdf",
         "notes":    "Aqua Surface Reflectance Daily L2G",
     },
-
     # ── Aerosol daily ─────────────────────────────────────────────────
     "MOD04_L2": {
         "cadence":  "daily",
@@ -57,7 +35,17 @@ PRODUCT_REGISTRY = {
         "file_ext": ".hdf",
         "notes":    "Aqua Aerosol 5-Min L2 Swath",
     },
-
+    # ── BRDF-Adjusted Reflectance daily ──────────────────────────────
+    "MCD43A4": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "MODIS BRDF-Adjusted Reflectance Daily 500m (nadir + SZA=45°)",
+    },
+    "MCD43C4": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "MODIS BRDF-Adjusted Reflectance Daily 0.05deg CMG (nadir + SZA=45°)",
+    },
     # ── Surface Reflectance 8-day ─────────────────────────────────────
     "MOD09A1": {
         "cadence":  "8day",
@@ -69,7 +57,6 @@ PRODUCT_REGISTRY = {
         "file_ext": ".hdf",
         "notes":    "Aqua Surface Reflectance 8-Day L3 500m",
     },
-
     # ── Vegetation Index 16-day ───────────────────────────────────────
     "MOD13A1": {
         "cadence":  "16day",
@@ -86,7 +73,6 @@ PRODUCT_REGISTRY = {
         "file_ext": ".hdf",
         "notes":    "Terra Vegetation Indices 16-Day L3 1km",
     },
-
     # ── Land Cover yearly ─────────────────────────────────────────────
     "MCD12Q1": {
         "cadence":  "yearly",
@@ -112,7 +98,6 @@ def get_product_info(product_name: str) -> dict:
     if product_name in PRODUCT_REGISTRY:
         return PRODUCT_REGISTRY[product_name]
 
-    # Unknown product → warn and assume 8-day (conservative default)
     import warnings
     warnings.warn(
         f"Product '{product_name}' not found in PRODUCT_REGISTRY. "

--- a/pyVPRM/sat_managers/product_registry.py
+++ b/pyVPRM/sat_managers/product_registry.py
@@ -22,6 +22,17 @@ PRODUCT_REGISTRY = {
         "file_ext": ".hdf",
         "notes":    "MAIAC Aerosol Optical Depth",
     },
+    "MCD43A4": {
+        "cadence":  "daily",        #  cambiar de 16day a daily
+        "file_ext": ".hdf",
+        "notes":    "MODIS BRDF-Adjusted Reflectance Daily 500m (nadir + SZA=45°) Collection 061",
+    },
+    "MCD43C4": {
+        "cadence":  "daily",
+        "file_ext": ".hdf",
+        "notes":    "MODIS BRDF-Adjusted Reflectance Daily 0.05deg CMG global (nadir + SZA=45°)",
+        "global":   True,   # ← sin tiles
+    },
 
     # ── Surface Reflectance daily ─────────────────────────────────────
     "MOD09GA": {


### PR DESCRIPTION
Description:
## Summary
Adds a complete workflow to download MODIS products from NASA LAADS DAAC.

## New files
- sat_managers/lads_downloader.py — main downloader class
- sat_managers/product_registry.py — product catalog (MCD19A1, MCD43A4, MOD09A1, etc.)
- sat_managers/gen_tasks.py — task list generator for SLURM
- sat_managers/download_modis_new_parallel.py — parallel downloader
- sat_managers/download_modis_new_submit.sh — SLURM submit script
- sat_managers/README_MCD19A1_downloader.md — full documentation

## Supported products
- MCD19A1.061: MAIAC daily 500m
- MCD43A4.061: BRDF-corrected daily 500m  
- MOD09A1/MYD09A1: 8-day composites
- MOD13A1: 16-day vegetation index
- MCD12Q1: yearly land cover

## Usage
See README_MCD19A1_downloader.md