### PR TITLE
1/8 Fix dual-regional ESMF weight generation

### DIFF
--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -170,7 +170,7 @@ class vprm_preprocessor:
                 ds_out_esmf = to_esmf_grid(out_grid)
                 src_grid_esmf.to_netcdf(src_temp_path)
                 ds_out_esmf.to_netcdf(dest_temp_path)
-                exec_str = "ESMF_RegridWeightGen --source {} --destination {} --weight {} -m {} -r --netcdf4 --src_regional --dest_regional ".format(
+                exec_str = "ESMF_RegridWeightGen --source {} --destination {} --weight {} -m {} -r --netcdf4 ".format(
                     src_temp_path,
                     dest_temp_path,
                     regridder_save_path,
@@ -673,8 +673,7 @@ class vprm_preprocessor:
                 logger.debug(f"wrote dest regridder: {dest_temp_path}")
                 exec_str = (
                     "ESMF_RegridWeightGen --source {} --destination {} "
-                    "--weight {} -m conserve -r --netcdf4 --src_regional"
-                    " --dest_regional --ignore_unmapped"
+                    "--weight {} -m conserve -r --netcdf4 --ignore_unmapped"
                 ).format(src_temp_path, dest_temp_path, regridder_save_path)
                 if mpi is True:
                     exec_str = "mpirun -np {} ".format(n_cpus) + exec_str

--- a/pyVPRM/meteorologies/era5_monthly_xr.py
+++ b/pyVPRM/meteorologies/era5_monthly_xr.py
@@ -89,7 +89,7 @@ class met_data_handler(met_data_handler_base):
                 )
                 self.ds_in_t.to_netcdf(src_temp_path)
                 t_ds_out.to_netcdf(dest_temp_path)
-                cmd = "ESMF_RegridWeightGen --source {} --destination {} --weight {} -m bilinear --64bit_offset  --extrap_method nearestd  --no_log".format(
+                cmd = "ESMF_RegridWeightGen --source {} --destination {} --weight {} -m bilinear -r --64bit_offset  --extrap_method nearestd  --no_log".format(
                     src_temp_path, dest_temp_path, weights
                 )
                 if self.mpi:

--- a/tests/test_esmf_regional_commands.py
+++ b/tests/test_esmf_regional_commands.py
@@ -1,0 +1,240 @@
+"""Regression tests for dual-regional ESMF command construction."""
+
+import numpy as np
+import pytest
+import rioxarray  # noqa: F401
+import xarray as xr
+
+from pyVPRM.VPRM import vprm_preprocessor
+from pyVPRM.meteorologies.era5_monthly_xr import met_data_handler
+from pyVPRM.sat_managers.base_manager import satellite_data_manager
+
+
+class CapturedESMFCommand(RuntimeError):
+    """Stop a test immediately after capturing an ESMF command string."""
+
+
+def make_satellite_grid():
+    """Build a minimal projected two-by-two satellite grid.
+
+    Returns
+    -------
+    xarray.Dataset
+        EPSG:2193 grid with one-dimensional ``x`` and ``y`` coordinates.
+    """
+
+    grid = xr.Dataset(coords={"y": [200.0, 100.0], "x": [100.0, 200.0]})
+    grid = grid.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    return grid.rio.write_crs("EPSG:2193").rio.write_transform()
+
+
+def make_preprocessor():
+    """Build a minimally initialized preprocessor for command tests.
+
+    Returns
+    -------
+    pyVPRM.VPRM.vprm_preprocessor
+        Preprocessor with a projected satellite grid and one CPU.
+    """
+
+    preprocessor = object.__new__(vprm_preprocessor)
+    preprocessor.sat_imgs = satellite_data_manager(sat_img=make_satellite_grid())
+    preprocessor.n_cpus = 1
+    return preprocessor
+
+
+def make_era5_handler():
+    """Build a minimally initialized ERA5 handler for command tests.
+
+    Returns
+    -------
+    pyVPRM.meteorologies.era5_monthly_xr.met_data_handler
+        Handler with a one-cell source dataset and no existing regridder.
+    """
+
+    handler = object.__new__(met_data_handler)
+    handler.in_era5_grid = True
+    handler.regridder = None
+    handler.mpi = False
+    handler.ds_in_t = xr.Dataset(
+        {"temperature": (("lat", "lon"), np.ones((1, 1)))},
+        coords={"lat": [48.0], "lon": [11.0]},
+    )
+    handler.data = handler.ds_in_t.copy()
+    return handler
+
+
+def capture_esmf_command(monkeypatch):
+    """Replace ESMF execution with command capture and an immediate stop.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Pytest fixture used to replace ``os.system`` in the VPRM module.
+
+    Returns
+    -------
+    list[str]
+        Mutable single-command capture container.
+    """
+
+    commands = []
+
+    def capture(command):
+        """Record an ESMF command and stop before external execution.
+
+        Parameters
+        ----------
+        command : str
+            Complete ESMF command constructed by the preprocessor.
+
+        Raises
+        ------
+        CapturedESMFCommand
+            Always, after recording the command.
+        """
+
+        commands.append(command)
+        raise CapturedESMFCommand(command)
+
+    monkeypatch.setattr("pyVPRM.VPRM.os.system", capture)
+    return commands
+
+
+def assert_dual_regional_flags(command):
+    """Assert documented ESMF semantics for two regional grids.
+
+    Parameters
+    ----------
+    command : str
+        Complete ESMF_RegridWeightGen command string.
+
+    Returns
+    -------
+    None
+        The test fails if conflicting global/regional flags are present.
+    """
+
+    assert " -r " in command
+    assert "--src_regional" not in command
+    assert "--dest_regional" not in command
+
+
+def test_to_wrf_output_uses_dual_regional_esmf_flags(monkeypatch, tmp_path):
+    """Use ``-r`` alone when building WRF output regridding weights.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to capture the ESMF command.
+    tmp_path : pathlib.Path
+        Temporary directory used for SCRIP-grid and weight paths.
+
+    Returns
+    -------
+    None
+        The test captures the command before ESMF or xESMF can execute.
+    """
+
+    preprocessor = make_preprocessor()
+    commands = capture_esmf_command(monkeypatch)
+    output_grid = {
+        "lons": np.array([172.0, 172.1]),
+        "lats": np.array([-37.1, -37.0]),
+    }
+
+    with pytest.raises(CapturedESMFCommand):
+        preprocessor.to_wrf_output(
+            output_grid,
+            driver="ESMF_RegridWeightGen",
+            regridder_save_path=tmp_path / "wrf_weights.nc",
+            mpi=False,
+        )
+
+    assert len(commands) == 1
+    assert_dual_regional_flags(commands[0])
+
+
+def test_land_cover_weights_use_dual_regional_esmf_flags(monkeypatch, tmp_path):
+    """Use ``-r`` alone when building fractional land-cover weights.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to capture the ESMF command.
+    tmp_path : pathlib.Path
+        Temporary directory used for SCRIP-grid and weight paths.
+
+    Returns
+    -------
+    None
+        The test captures the command before ESMF or xESMF can execute.
+    """
+
+    preprocessor = make_preprocessor()
+    preprocessor.map_to_vprm_class = {1: 3}
+    commands = capture_esmf_command(monkeypatch)
+    source = make_satellite_grid().assign(
+        band_1=(("y", "x"), np.ones((2, 2), dtype=np.int16))
+    )
+    land_cover_map = satellite_data_manager(sat_img=source)
+
+    with pytest.raises(CapturedESMFCommand):
+        preprocessor.add_land_cover_map(
+            land_cover_map,
+            regridder_save_path=tmp_path / "land_cover_weights.nc",
+            mpi=False,
+        )
+
+    assert len(commands) == 1
+    assert "--ignore_unmapped" in commands[0]
+    assert_dual_regional_flags(commands[0])
+
+
+def test_era5_weights_use_dual_regional_esmf_flags(monkeypatch, tmp_path):
+    """Use ``-r`` alone when building ERA5-to-satellite weights.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to capture the ESMF command.
+    tmp_path : pathlib.Path
+        Temporary directory used for SCRIP-grid and weight paths.
+
+    Returns
+    -------
+    None
+        The test captures the command before ESMF or xESMF can execute.
+    """
+
+    handler = make_era5_handler()
+    commands = []
+
+    def capture(command):
+        """Record an ERA5 ESMF command and stop before execution.
+
+        Parameters
+        ----------
+        command : str
+            Complete ESMF command constructed by the meteorology handler.
+
+        Raises
+        ------
+        CapturedESMFCommand
+            Always, after recording the command.
+        """
+
+        commands.append(command)
+        raise CapturedESMFCommand(command)
+
+    monkeypatch.setattr("pyVPRM.meteorologies.era5_monthly_xr.os.system", capture)
+    destination = xr.Dataset(coords={"lat": [48.1], "lon": [11.1]})
+
+    with pytest.raises(CapturedESMFCommand):
+        handler.regrid(
+            dataset=destination,
+            weights=tmp_path / "era5_weights.nc",
+        )
+
+    assert len(commands) == 1
+    assert_dual_regional_flags(commands[0])


### PR DESCRIPTION
# Fix dual-regional ESMF weight generation

## Summary

`ESMF_RegridWeightGen` distinguishes between a source-only regional grid, a destination-only regional grid, and the case where both grids are regional. Several pyVPRM command builders used a contradictory combination of these options. This PR uses ESMF's dual-regional `-r` option consistently when both source and destination grids are regional.

The correction applies to:

- ERA5-to-satellite weight generation;
- land-cover-to-satellite conservative weights; and
- satellite-to-WRF weight generation.

## Why

The previous commands combined `-r` with source- and destination-specific regional flags. In the `ESMF_RegridWeightGen` command-line interface, `--src_regional` means *source regional AND destination global*, while `--dst_regional` means *destination regional AND source global*; `-r` is the option for *both grids regional*. Passing both `--src_regional` and `--dst_regional` is therefore contradictory.

Treating both grids as regional is required for these pyVPRM workflows and prevents ESMF from applying global-grid topology assumptions. The documented options are listed in the [ESMF_RegridWeightGen reference manual](https://earthsystemmodeling.org/docs/release/ESMF_8_4_1/ESMF_refdoc/node3.html).

## Validation

- Added regression tests that capture the constructed ESMF command before
  execution for the ERA5, land-cover, and WRF paths.
- The tests assert that every affected command contains `-r` and contains
  neither `--src_regional` nor `--dest_regional`.
- Focused test suite: `3 passed`.

## Visual evidence
I think it is likely (though I have not tested) that the `--src_regional --dest_regional` contradictory combination results in some really minimal regrid errors at all places/times. As demonstrated below it does cause the regrid to implode really spectacularly in the New Zealand area. The NZ ERA5 met regrid put pronounced East-West stripes into the regridded data:

regridded ERA5 t2m with `-r` (looks like New Zealand 👍):
<img width="2000" height="1200" alt="L389_vprm_base_model_in_get_vprm_variables_ERA5_t2m_t0_02" src="https://github.com/user-attachments/assets/7eb92bdc-b490-490c-ba23-15843ea03aee" />

regridded ERA5 t2m with `--src_regional --dest_regional` (does NOT look like New Zealand 😭):
<img width="2000" height="1200" alt="L396_vprm_base_model_in_get_vprm_variables_ERA5_t2m_t0_without_rflag" src="https://github.com/user-attachments/assets/ba17ba10-3c46-4bf2-b890-8112db837748" />

I generated the below diagnostic images while investigating a regional-grid failure. The longitude error field showed pronounced horizontal striping without the dual-regional option; with `-r`, it is reduced to the small numerical residual expected from coordinate transformation and interpolation.

Before: longitude error with `--src_regional --dest_regional`:
<img width="640" height="480" alt="lon_error" src="https://github.com/user-attachments/assets/c5b57b6f-5a99-4b0e-a155-fc554facce99" />

After: longitude error with `-r`:
<img width="640" height="480" alt="lon_error_rflag" src="https://github.com/user-attachments/assets/81ab1ab0-c25b-40e9-b412-4ac2f16fb437" />

Before: latitude error with `--src_regional --dest_regional`:
<img width="640" height="480" alt="lat_error" src="https://github.com/user-attachments/assets/b19c66ca-b5b3-4d23-ad80-ab6d6d7eec5b" />

After: latitude error with `-r`:
<img width="640" height="480" alt="lat_error_rflag" src="https://github.com/user-attachments/assets/79800b84-4f1d-4546-800f-56d3d732c757" />
