### PR TITLE
3/8 Distinguish missing and no-flux VPRM cells

### DIFF
--- a/pyVPRM/vprm_models/vprm_base_model.py
+++ b/pyVPRM/vprm_models/vprm_base_model.py
@@ -410,7 +410,9 @@ class vprm_base_model:
                 regridder_weights (str): Path to the weights file for regridding from ERA5
                                          to the satellite grid
                 no_flux_veg_types (list of ints): flux type ids that get a default GPP/NEE of 0
-                                                  (e.g. oceans, deserts...)
+                                                  (e.g. oceans, deserts...). Cells with no
+                                                  fractional coverage in any remaining
+                                                  flux-capable class are returned as zero.
             Returns:
                     None
         """
@@ -435,6 +437,11 @@ class vprm_base_model:
 
         lc_classes = [i for i in lc_classes if ((i not in no_flux_veg_types) & (i in self.fit_params_dict.keys()))]
         lc_classes = np.atleast_1d(lc_classes)
+        flux_capable_fraction = None
+        if mode == "2d":
+            flux_capable_fraction = self.vprm_pre.land_cover_type.sat_img.sel(
+                {"vprm_classes": lc_classes}
+            ).sum(dim="vprm_classes")
         for i in lc_classes:
             if mode == "2d":
                 inputs = self._get_vprm_variables(
@@ -477,6 +484,12 @@ class vprm_base_model:
                 )
                 ret_res["nee"] = -ret_res["gpp"] + xr.concat(respirations, dim="z").sum(
                     dim="z", skipna=True, min_count=1
+                )
+                ret_res["gpp"] = ret_res["gpp"].where(
+                    flux_capable_fraction > 0.0, other=0.0
+                )
+                ret_res["nee"] = ret_res["nee"].where(
+                    flux_capable_fraction > 0.0, other=0.0
                 )
         else:
             ret_res["gpp"] = xr.concat(gpps, dim="veg_classes")

--- a/pyVPRM/vprm_models/vprm_base_model.py
+++ b/pyVPRM/vprm_models/vprm_base_model.py
@@ -472,9 +472,11 @@ class vprm_base_model:
                 ret_res["gpp"] = gpps[0]
                 ret_res["nee"] = -gpps[0] + respirations[0]
             else:
-                ret_res["gpp"] = xr.concat(gpps, dim="z").sum(dim="z")
+                ret_res["gpp"] = xr.concat(gpps, dim="z").sum(
+                    dim="z", skipna=True, min_count=1
+                )
                 ret_res["nee"] = -ret_res["gpp"] + xr.concat(respirations, dim="z").sum(
-                    dim="z"
+                    dim="z", skipna=True, min_count=1
                 )
         else:
             ret_res["gpp"] = xr.concat(gpps, dim="veg_classes")

--- a/tests/test_missing_flux_aggregation.py
+++ b/tests/test_missing_flux_aggregation.py
@@ -1,0 +1,136 @@
+"""Regression tests for missing classwise VPRM flux aggregation."""
+
+from types import MethodType, SimpleNamespace
+
+import numpy as np
+import xarray as xr
+
+from pyVPRM.vprm_models.vprm_base_model import vprm_base_model
+
+
+def make_model(inputs):
+    """Build a two-class model returning fixed VPRM input fields.
+
+    Parameters
+    ----------
+    inputs : dict[str, xarray.DataArray]
+        VPRM driver fields returned for each flux-capable class.
+
+    Returns
+    -------
+    pyVPRM.vprm_models.vprm_base_model.vprm_base_model
+        Minimally initialized model suitable for aggregation tests.
+    """
+
+    model = object.__new__(vprm_base_model)
+    model.fit_params_dict = {
+        3: {"lamb": 0.5, "par0": 1000.0, "alpha": 0.2, "beta": 1.0},
+        4: {"lamb": 0.5, "par0": 1000.0, "alpha": 0.2, "beta": 1.0},
+    }
+    model.vprm_pre = SimpleNamespace(
+        land_cover_type=SimpleNamespace(
+            sat_img=xr.DataArray(
+                [[0.75], [0.25]],
+                dims=("vprm_classes", "x"),
+                coords={"vprm_classes": [3, 4], "x": [0]},
+            )
+        )
+    )
+
+    def get_inputs(self, *args, **kwargs):
+        """Return fixed drivers for each requested VPRM class.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments accepted by the model hook.
+        **kwargs
+            Keyword arguments accepted by the model hook.
+
+        Returns
+        -------
+        dict[str, xarray.DataArray]
+            Fixed input fields supplied to the VPRM equations.
+        """
+
+        del self, args, kwargs
+        return inputs
+
+    model._get_vprm_variables = MethodType(get_inputs, model)
+    return model
+
+
+def make_inputs(evi, tcorr):
+    """Build otherwise-valid VPRM inputs with selected missing drivers.
+
+    Parameters
+    ----------
+    evi : float
+        Enhanced Vegetation Index input value.
+    tcorr : float
+        Respiration temperature input value in degrees Celsius.
+
+    Returns
+    -------
+    dict[str, xarray.DataArray]
+        One-cell VPRM input fields.
+    """
+
+    def field(value):
+        """Wrap a scalar as a one-cell xarray field.
+
+        Parameters
+        ----------
+        value : float
+            Scalar value to store.
+
+        Returns
+        -------
+        xarray.DataArray
+            One-dimensional field over the test cell.
+        """
+
+        return xr.DataArray([value], dims="x")
+
+    return {
+        "Ps": field(1.0),
+        "Ws": field(1.0),
+        "Ts": field(1.0),
+        "evi": field(evi),
+        "par": field(1000.0),
+        "tcorr": field(tcorr),
+    }
+
+
+def test_all_missing_gpp_contributions_remain_missing():
+    """Keep GPP and NEE missing when every classwise GPP is missing.
+
+    Returns
+    -------
+    None
+        The test verifies that an unresolved EVI is not silently converted to
+        zero GPP during cross-class aggregation.
+    """
+
+    model = make_model(make_inputs(evi=np.nan, tcorr=20.0))
+    fluxes = model.make_vprm_predictions(date=object())
+
+    assert bool(fluxes["gpp"].isnull().all())
+    assert bool(fluxes["nee"].isnull().all())
+
+
+def test_all_missing_respiration_contributions_remain_missing():
+    """Keep NEE missing when every classwise respiration is missing.
+
+    Returns
+    -------
+    None
+        The test verifies that a missing respiration temperature input is not
+        silently converted to zero respiration during aggregation.
+    """
+
+    model = make_model(make_inputs(evi=0.5, tcorr=np.nan))
+    fluxes = model.make_vprm_predictions(date=object())
+
+    assert bool(fluxes["gpp"].notnull().all())
+    assert bool(fluxes["nee"].isnull().all())

--- a/tests/test_missing_flux_aggregation.py
+++ b/tests/test_missing_flux_aggregation.py
@@ -60,7 +60,7 @@ def make_model(inputs):
     return model
 
 
-def make_inputs(evi, tcorr):
+def make_inputs(evi, tcorr, n_cells=1):
     """Build otherwise-valid VPRM inputs with selected missing drivers.
 
     Parameters
@@ -69,6 +69,8 @@ def make_inputs(evi, tcorr):
         Enhanced Vegetation Index input value.
     tcorr : float
         Respiration temperature input value in degrees Celsius.
+    n_cells : int, default=1
+        Number of identical test cells to create.
 
     Returns
     -------
@@ -90,7 +92,7 @@ def make_inputs(evi, tcorr):
             One-dimensional field over the test cell.
         """
 
-        return xr.DataArray([value], dims="x")
+        return xr.DataArray(np.full(n_cells, value), dims="x")
 
     return {
         "Ps": field(1.0),
@@ -134,3 +136,31 @@ def test_all_missing_respiration_contributions_remain_missing():
 
     assert bool(fluxes["gpp"].notnull().all())
     assert bool(fluxes["nee"].isnull().all())
+
+
+def test_no_flux_cells_are_zero_without_hiding_missing_active_fluxes():
+    """Return zero only where no flux-capable class has coverage.
+
+    Returns
+    -------
+    None
+        The test verifies that an all-no-flux cell is zero while a neighboring
+        active cell with missing EVI remains missing.
+    """
+
+    model = make_model(make_inputs(evi=np.nan, tcorr=20.0, n_cells=2))
+    model.fit_params_dict = {
+        3: {"lamb": 0.5, "par0": 1000.0, "alpha": 0.2, "beta": 1.0},
+    }
+    model.vprm_pre.land_cover_type.sat_img = xr.DataArray(
+        [[1.0, 0.0], [0.0, 1.0]],
+        dims=("vprm_classes", "x"),
+        coords={"vprm_classes": [0, 3], "x": [0, 1]},
+    )
+
+    fluxes = model.make_vprm_predictions(date=object())
+
+    assert fluxes["gpp"].sel(x=0).item() == 0.0
+    assert fluxes["nee"].sel(x=0).item() == 0.0
+    assert np.isnan(fluxes["gpp"].sel(x=1).item())
+    assert np.isnan(fluxes["nee"].sel(x=1).item())


### PR DESCRIPTION
# Distinguish missing and no-flux VPRM cells

## Summary

Distinguish genuinely missing model results from cells with no flux-capable land-cover fraction when aggregating GPP and respiration across VPRM classes.

## Why

By default, xarray reduces an all-`NaN` array with `sum()` to zero. In VPRM, that could turn an all-missing stack of landcover-classwise GPP or respiration terms into a physically meaningful-looking zero. The resulting NEE could therefore appear valid even though a required model input was missing.

For example, a cloud-obscured EVI value can make every classwise GPP term missing. Likewise, a missing respiration temperature input (`tcorr`) can make every classwise respiration term missing. Neither condition should be reported as zero biological flux. Conversely, a cell whose fractional land cover contains no flux-capable class is structurally a zero-flux cell, not a missing-data cell.

## Change

Use xarray's `skipna=True, min_count=1` when summing classwise GPP and respiration contributions. The aggregation still ignores an individual missing class when another class contributes a valid value, but returns `NaN` when no valid contribution exists.

For fractional (two-dimensional) land-cover inputs, calculate the combined coverage of all flux-capable classes. Explicitly set GPP and NEE to zero only where that coverage is zero. Thus an active cell with missing EVI remains `NaN`, whereas an ocean, desert, or other no-flux cell is reported as zero.

## Validation

- Added a regression test confirming that missing EVI keeps GPP and NEE missing rather than converting GPP to zero.
- Added a regression test confirming that missing respiration temperature keeps NEE missing rather than converting respiration to zero.
- Added a regression test confirming that an all-no-flux cell is zero while an adjacent active cell with missing EVI remains missing.
- Focused test suite: `3 passed`.