### PR TITLE
4/8 Feature GISA-new impervious surface

### DIFF
--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -1,3 +1,5 @@
+"""Preprocess satellite, land-cover, and static ancillary inputs for VPRM."""
+
 import warnings
 
 warnings.filterwarnings("ignore")
@@ -39,8 +41,20 @@ regridder_options["conservative"] = "conserve"
 
 
 class vprm_preprocessor:
-    """
-    Main class for the  Vegetation Photosynthesis and Respiration Model
+    """Prepare satellite and static spatial inputs for VPRM calculations.
+
+    Parameters
+    ----------
+    vprm_config_path : str or pathlib.Path
+        VPRM vegetation-class configuration file.
+    land_cover_map : satellite_data_manager, optional
+        Pre-calculated VPRM land-cover fractions.
+    verbose : bool, default=False
+        Enable verbose processing output.
+    n_cpus : int, default=1
+        Number of CPUs available to regridding operations.
+    flux_tower_instances : list, optional
+        Flux-tower data objects used for fitting workflows.
     """
 
     def __init__(
@@ -79,6 +93,7 @@ class vprm_preprocessor:
         self.empty_xr_lat_lon_grid = None
 
         self.land_cover_type = land_cover_map
+        self.impervious_surface_area = None
         # land_cover_type: tmin, topt, tmax
 
         with open(vprm_config_path, "r") as stream:
@@ -724,6 +739,123 @@ class vprm_preprocessor:
                 self.land_cover_type.save(save_path)
         return
 
+    def add_impervious_surface_area(
+        self,
+        impervious_surface_area,
+        var_name="impervious_surface_percentage",
+        regridder_save_path=None,
+        n_cpus=None,
+        mpi=True,
+        logs=False,
+    ):
+        """Conservatively regrid an impervious-surface field to the satellite grid.
+
+        Parameters
+        ----------
+        impervious_surface_area : satellite_data_manager
+            Loaded and spatially cropped continuous impervious-surface data.
+            ``var_name`` must hold percentages from 0 to 100.
+        var_name : str, default="impervious_surface_percentage"
+            Name of the impervious-surface percentage variable.
+        regridder_save_path : str or pathlib.Path
+            Grid-specific path for conservative ESMF regridding weights.
+        n_cpus : int, optional
+            Number of MPI processes used while generating weights. Defaults to
+            :attr:`n_cpus`.
+        mpi : bool, default=True
+            Use ``mpirun`` when generating new ESMF weights.
+        logs : bool, default=False
+            Preserve ESMF log files when generating weights.
+
+        Returns
+        -------
+        None
+            The regridded percentage field is stored in
+            :attr:`impervious_surface_area` on the VPRM satellite grid.
+
+        Raises
+        ------
+        TypeError
+            If the supplied data are not managed by
+            :class:`satellite_data_manager`.
+        ValueError
+            If the requested variable or weight-cache path is missing.
+        RuntimeError
+            If ESMF weight generation fails.
+        """
+        if not isinstance(impervious_surface_area, satellite_data_manager):
+            raise TypeError(
+                "impervious_surface_area must be a satellite_data_manager instance."
+            )
+        if var_name not in impervious_surface_area.sat_img:
+            raise ValueError(
+                "Impervious-surface data do not contain {!r}.".format(var_name)
+            )
+        if regridder_save_path is None:
+            raise ValueError("regridder_save_path is required for ISA regridding.")
+
+        if n_cpus is None:
+            n_cpus = self.n_cpus
+        regridder_save_path = os.fspath(regridder_save_path)
+        regridder_directory = os.path.dirname(regridder_save_path)
+        if regridder_directory:
+            os.makedirs(regridder_directory, exist_ok=True)
+
+        if not os.path.exists(regridder_save_path):
+            src_grid = to_esmf_grid(impervious_surface_area.sat_img)
+            dest_grid = to_esmf_grid(self.sat_imgs.sat_img)
+            src_temp_path = os.path.join(
+                regridder_directory, "{}.nc".format(str(uuid.uuid4()))
+            )
+            dest_temp_path = os.path.join(
+                regridder_directory, "{}.nc".format(str(uuid.uuid4()))
+            )
+            try:
+                src_grid.to_netcdf(src_temp_path)
+                dest_grid.to_netcdf(dest_temp_path)
+                command = (
+                    "ESMF_RegridWeightGen --source {} --destination {} --weight {} "
+                    "-m conserve -r --netcdf4 --src_regional --dest_regional "
+                    "--ignore_unmapped"
+                ).format(src_temp_path, dest_temp_path, regridder_save_path)
+                if mpi:
+                    command = "mpirun -np {} ".format(n_cpus) + command
+                if not logs:
+                    command += " --no_log"
+                logger.info("Run: {}".format(command))
+                if os.system(command) != 0:
+                    raise RuntimeError("ESMF failed to generate ISA regridding weights.")
+            finally:
+                for temporary_path in [src_temp_path, dest_temp_path]:
+                    if os.path.exists(temporary_path):
+                        os.remove(temporary_path)
+
+        import xesmf as xe
+
+        regridder = xe.Regridder(
+            make_xesmf_grid(impervious_surface_area.sat_img),
+            make_xesmf_grid(self.sat_imgs.sat_img),
+            "conservative",
+            weights=regridder_save_path,
+            reuse_weights=True,
+        )
+        regridded = regridder(impervious_surface_area.sat_img[[var_name]])
+        regridded = regridded.assign_coords(
+            {
+                "x": self.sat_imgs.sat_img.coords["x"].values,
+                "y": self.sat_imgs.sat_img.coords["y"].values,
+            }
+        )
+        regridded[var_name].attrs.update(
+            {
+                "long_name": "area-weighted percent impervious surface",
+                "units": "percent",
+                "source_product": "GMIS",
+            }
+        )
+        self.impervious_surface_area = satellite_data_manager(sat_img=regridded)
+        return
+
     def calc_min_max_evi_lswi(self):
         """
         Calculate the minimim and maximum EVI and LSWI
@@ -1178,15 +1310,21 @@ class vprm_preprocessor:
         return dj
 
     def add_vprm_insts(self, vprm_insts, allow_reproject=True):
-        """
-        Merge one or more other vprm_preprocessor instances' satellite/land-cover
-        tiles into this one (e.g. combining adjacent spatial tiles into a
-        single larger domain).
-    
-        Parameters:
-                vprm_insts (list): other vprm_preprocessor instances to merge in
-                allow_reproject (bool): reproject incoming tiles onto this
-                                        instance's grid/CRS if they don't already match
+        """Merge compatible VPRM preprocessors, including static ISA fields.
+
+        Parameters
+        ----------
+        vprm_insts : list[vprm_preprocessor]
+            Preprocessors whose spatial products will be tiled onto this
+            instance.
+        allow_reproject : bool, default=True
+            Reproject satellite data before merging when necessary.
+
+        Returns
+        -------
+        None
+            Satellite, land-cover, and impervious-surface products are merged
+            in place when present.
         """
         if isinstance(self.sat_imgs, satellite_data_manager):
             self.sat_imgs.add_tile(
@@ -1200,4 +1338,13 @@ class vprm_preprocessor:
         if self.land_cover_type is not None:
             self.land_cover_type.add_tile(
                 [v.land_cover_type for v in vprm_insts], reproject=False
+            )
+        if self.impervious_surface_area is not None:
+            self.impervious_surface_area.add_tile(
+                [
+                    v.impervious_surface_area
+                    for v in vprm_insts
+                    if v.impervious_surface_area is not None
+                ],
+                reproject=False,
             )

--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -17,6 +17,7 @@ from pyVPRM.lib.functions import (
     to_esmf_grid,
     replace_inf_runs_ignore_nans
 )
+from pyVPRM.lib.regridding import conservative_regrid
 from scipy.ndimage import uniform_filter
 from pyproj import Transformer
 import copy
@@ -747,6 +748,7 @@ class vprm_preprocessor:
         n_cpus=None,
         mpi=True,
         logs=False,
+        max_source_cells=None,
     ):
         """Conservatively regrid an impervious-surface field to the satellite grid.
 
@@ -766,6 +768,10 @@ class vprm_preprocessor:
             Use ``mpirun`` when generating new ESMF weights.
         logs : bool, default=False
             Preserve ESMF log files when generating weights.
+        max_source_cells : int, optional
+            Maximum source cells in one ESMF invocation. Larger regular source
+            grids are split into disjoint y-axis partitions and their
+            conservative destination contributions are summed.
 
         Returns
         -------
@@ -796,61 +802,20 @@ class vprm_preprocessor:
 
         if n_cpus is None:
             n_cpus = self.n_cpus
-        regridder_save_path = os.fspath(regridder_save_path)
-        regridder_directory = os.path.dirname(regridder_save_path)
-        if regridder_directory:
-            os.makedirs(regridder_directory, exist_ok=True)
-
-        if not os.path.exists(regridder_save_path):
-            src_grid = to_esmf_grid(impervious_surface_area.sat_img)
-            dest_grid = to_esmf_grid(self.sat_imgs.sat_img)
-            src_temp_path = os.path.join(
-                regridder_directory, "{}.nc".format(str(uuid.uuid4()))
-            )
-            dest_temp_path = os.path.join(
-                regridder_directory, "{}.nc".format(str(uuid.uuid4()))
-            )
-            try:
-                src_grid.to_netcdf(src_temp_path)
-                dest_grid.to_netcdf(dest_temp_path)
-                command = (
-                    "ESMF_RegridWeightGen --source {} --destination {} --weight {} "
-                    "-m conserve -r --netcdf4 --src_regional --dest_regional "
-                    "--ignore_unmapped"
-                ).format(src_temp_path, dest_temp_path, regridder_save_path)
-                if mpi:
-                    command = "mpirun -np {} ".format(n_cpus) + command
-                if not logs:
-                    command += " --no_log"
-                logger.info("Run: {}".format(command))
-                if os.system(command) != 0:
-                    raise RuntimeError("ESMF failed to generate ISA regridding weights.")
-            finally:
-                for temporary_path in [src_temp_path, dest_temp_path]:
-                    if os.path.exists(temporary_path):
-                        os.remove(temporary_path)
-
-        import xesmf as xe
-
-        regridder = xe.Regridder(
-            make_xesmf_grid(impervious_surface_area.sat_img),
-            make_xesmf_grid(self.sat_imgs.sat_img),
-            "conservative",
-            weights=regridder_save_path,
-            reuse_weights=True,
-        )
-        regridded = regridder(impervious_surface_area.sat_img[[var_name]])
-        regridded = regridded.assign_coords(
-            {
-                "x": self.sat_imgs.sat_img.coords["x"].values,
-                "y": self.sat_imgs.sat_img.coords["y"].values,
-            }
+        regridded = conservative_regrid(
+            impervious_surface_area.sat_img[[var_name]],
+            self.sat_imgs.sat_img,
+            weight_path=regridder_save_path,
+            max_source_cells=max_source_cells,
+            n_cpus=n_cpus,
+            mpi=mpi,
+            logs=logs,
         )
         regridded[var_name].attrs.update(
             {
                 "long_name": "area-weighted percent impervious surface",
                 "units": "percent",
-                "source_product": "GMIS",
+                "source_product": type(impervious_surface_area).__name__,
             }
         )
         self.impervious_surface_area = satellite_data_manager(sat_img=regridded)

--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -806,6 +806,7 @@ class vprm_preprocessor:
             impervious_surface_area.sat_img[[var_name]],
             self.sat_imgs.sat_img,
             weight_path=regridder_save_path,
+            source_mask=impervious_surface_area.sat_img[var_name] > 0,
             max_source_cells=max_source_cells,
             n_cpus=n_cpus,
             mpi=mpi,

--- a/pyVPRM/lib/functions.py
+++ b/pyVPRM/lib/functions.py
@@ -247,7 +247,31 @@ def make_xesmf_grid(satellite_image, transformer = None):
     return pixel_grid
 
 
-def to_esmf_grid(sat_img):
+def to_esmf_grid(sat_img, grid_imask=None):
+    """Convert a regular grid to the SCRIP dataset consumed by ESMF.
+
+    Parameters
+    ----------
+    sat_img : xarray.Dataset or dict
+        Regular source or destination grid. Xarray inputs require
+        one-dimensional ``x`` and ``y`` coordinates and a rio CRS. Dictionary
+        inputs require ``lons`` and ``lats`` arrays.
+    grid_imask : xarray.DataArray or numpy.ndarray, optional
+        Integer or boolean ``y, x`` mask. Values of zero exclude cells from
+        ESMF weight generation; non-zero values retain them. If omitted, all
+        cells participate.
+
+    Returns
+    -------
+    xarray.Dataset
+        SCRIP-format grid description with centre coordinates, cell corners,
+        and ``grid_imask``.
+
+    Raises
+    ------
+    ValueError
+        If a supplied mask does not match the grid dimensions.
+    """
 
     if isinstance(sat_img, dict):
         x = sat_img["lons"]
@@ -292,7 +316,18 @@ def to_esmf_grid(sat_img):
         )
         x_center, y_center = t.transform(x_center, y_center)
         x_corner, y_corner = t.transform(x_corner, y_corner)
-    grid_imask = np.ones((ny, nx), dtype=np.int32)
+    if grid_imask is None:
+        grid_imask = np.ones((ny, nx), dtype=np.int32)
+    else:
+        if hasattr(grid_imask, "values"):
+            grid_imask = grid_imask.values
+        grid_imask = np.asarray(grid_imask, dtype=np.int32)
+        if grid_imask.shape != (ny, nx):
+            raise ValueError(
+                "grid_imask shape {} does not match y, x dimensions ({}, {}).".format(
+                    grid_imask.shape, ny, nx
+                )
+            )
 
     # generate output dataset
     dso = xr.Dataset()
@@ -876,5 +911,4 @@ def get_eth_canopy_height(lat, lon, radius_m=50, basepath="."):
     )
 
     return float(chm_box.mean())
-
 

--- a/pyVPRM/lib/regridding.py
+++ b/pyVPRM/lib/regridding.py
@@ -94,6 +94,7 @@ def _generate_conservative_weights(
     destination,
     *,
     weight_path,
+    source_mask,
     n_cpus,
     mpi,
     logs,
@@ -108,6 +109,8 @@ def _generate_conservative_weights(
         Complete destination dataset.
     weight_path : str or os.PathLike
         Weight-cache file to create.
+    source_mask : xarray.DataArray, optional
+        Zero/non-zero mask for source cells in this partition.
     n_cpus : int
         MPI process count when ``mpi`` is true.
     mpi : bool
@@ -139,7 +142,7 @@ def _generate_conservative_weights(
     destination_temp_path = os.path.join(
         weight_directory, "{}.nc".format(uuid.uuid4())
     )
-    to_esmf_grid(source).to_netcdf(source_temp_path)
+    to_esmf_grid(source, grid_imask=source_mask).to_netcdf(source_temp_path)
     to_esmf_grid(destination).to_netcdf(destination_temp_path)
 
     command = [
@@ -178,6 +181,7 @@ def conservative_regrid(
     destination,
     *,
     weight_path,
+    source_mask=None,
     max_source_cells=None,
     n_cpus=1,
     mpi=True,
@@ -201,6 +205,10 @@ def conservative_regrid(
     weight_path : str or os.PathLike
         Cache path for an unsplit weight file. Partitioned grids receive
         ``_src_###`` before the file extension.
+    source_mask : xarray.DataArray, optional
+        Zero/non-zero source-cell mask with ``y, x`` dimensions. Masked cells
+        do not participate in ESMF weight generation. Use this only when
+        excluding a cell is equivalent to a zero destination contribution.
     max_source_cells : int, optional
         Maximum source cells in one ESMF invocation. Larger source grids are
         split into disjoint contiguous y-axis partitions.
@@ -225,6 +233,11 @@ def conservative_regrid(
     """
     if not isinstance(source, xr.Dataset) or not isinstance(destination, xr.Dataset):
         raise ValueError("source and destination must both be xarray.Dataset instances.")
+    if source_mask is not None and tuple(source_mask.shape) != (
+        source.sizes["y"],
+        source.sizes["x"],
+    ):
+        raise ValueError("source_mask must have the same y, x shape as source.")
     source_slices = _source_y_slices(source, max_source_cells)
     _source_y_slices(destination, None)
 
@@ -233,6 +246,9 @@ def conservative_regrid(
     result = None
     for chunk_number, source_slice in enumerate(source_slices):
         source_chunk = source.isel(y=source_slice)
+        source_mask_chunk = (
+            None if source_mask is None else source_mask.isel(y=source_slice)
+        )
         chunk_weight_path = _weight_path(
             weight_path, chunk_number, len(source_slices)
         )
@@ -240,6 +256,7 @@ def conservative_regrid(
             source_chunk,
             destination,
             weight_path=chunk_weight_path,
+            source_mask=source_mask_chunk,
             n_cpus=n_cpus,
             mpi=mpi,
             logs=logs,

--- a/pyVPRM/lib/regridding.py
+++ b/pyVPRM/lib/regridding.py
@@ -1,0 +1,265 @@
+"""Conservative ESMF regridding utilities for regular xarray grids.
+
+The helpers in this module partition oversized source grids before generating
+conservative ESMF weights. Partition contributions are additive when ESMF
+uses destination-area normalisation, allowing high-resolution sources to be
+regridded without creating one prohibitively large ESMF mesh.
+"""
+
+import os
+import subprocess
+import uuid
+
+import xarray as xr
+from loguru import logger
+
+from pyVPRM.lib.functions import make_xesmf_grid, to_esmf_grid
+
+
+def _source_y_slices(source, max_source_cells):
+    """Return disjoint y-axis slices that respect a source-cell limit.
+
+    Parameters
+    ----------
+    source : xarray.Dataset
+        Source dataset with one-dimensional ``x`` and ``y`` coordinates.
+    max_source_cells : int or None
+        Maximum number of source cells in each returned slice. ``None``
+        returns one slice containing the complete source grid.
+
+    Returns
+    -------
+    list of slice
+        Contiguous, non-overlapping slices along the source ``y`` dimension.
+
+    Raises
+    ------
+    ValueError
+        If the source does not have non-empty one-dimensional spatial
+        coordinates, or if ``max_source_cells`` cannot contain one row.
+    """
+    if "x" not in source.coords or "y" not in source.coords:
+        raise ValueError("source must provide one-dimensional x and y coordinates.")
+    if source.coords["x"].ndim != 1 or source.coords["y"].ndim != 1:
+        raise ValueError("source x and y coordinates must be one-dimensional.")
+
+    nx = source.sizes["x"]
+    ny = source.sizes["y"]
+    if nx == 0 or ny == 0:
+        raise ValueError("source x and y dimensions must be non-empty.")
+    if max_source_cells is None:
+        return [slice(0, ny)]
+    if not isinstance(max_source_cells, int) or max_source_cells <= 0:
+        raise ValueError("max_source_cells must be a positive integer or None.")
+    if nx * ny <= max_source_cells:
+        return [slice(0, ny)]
+
+    rows_per_slice = max_source_cells // nx
+    if rows_per_slice == 0:
+        raise ValueError(
+            "max_source_cells must be at least as large as the source x dimension."
+        )
+    return [
+        slice(row_start, min(row_start + rows_per_slice, ny))
+        for row_start in range(0, ny, rows_per_slice)
+    ]
+
+
+def _weight_path(weight_path, chunk_number, chunk_count):
+    """Return the cache path for one source-grid partition.
+
+    Parameters
+    ----------
+    weight_path : str or os.PathLike
+        Requested weight-cache path.
+    chunk_number : int
+        Zero-based partition number.
+    chunk_count : int
+        Total number of source partitions.
+
+    Returns
+    -------
+    str
+        Weight-cache path. The original path is retained for an unsplit grid.
+    """
+    weight_path = os.fspath(weight_path)
+    if chunk_count == 1:
+        return weight_path
+    stem, extension = os.path.splitext(weight_path)
+    return "{}_src_{:03d}{}".format(stem, chunk_number, extension or ".nc")
+
+
+def _generate_conservative_weights(
+    source,
+    destination,
+    *,
+    weight_path,
+    n_cpus,
+    mpi,
+    logs,
+):
+    """Generate one cached ESMF conservative weight file when needed.
+
+    Parameters
+    ----------
+    source : xarray.Dataset
+        Source dataset for one grid partition.
+    destination : xarray.Dataset
+        Complete destination dataset.
+    weight_path : str or os.PathLike
+        Weight-cache file to create.
+    n_cpus : int
+        MPI process count when ``mpi`` is true.
+    mpi : bool
+        Whether to launch ESMF through ``mpirun``.
+    logs : bool
+        Whether ESMF PET log files should be retained.
+
+    Returns
+    -------
+    None
+        The weight file is created at ``weight_path`` when it is absent.
+
+    Raises
+    ------
+    RuntimeError
+        If ESMF weight generation fails. Temporary SCRIP grids are retained
+        on failure to support diagnosis.
+    """
+    weight_path = os.fspath(weight_path)
+    if os.path.exists(weight_path):
+        return
+
+    weight_directory = os.path.dirname(weight_path)
+    if weight_directory:
+        os.makedirs(weight_directory, exist_ok=True)
+    source_temp_path = os.path.join(
+        weight_directory, "{}.nc".format(uuid.uuid4())
+    )
+    destination_temp_path = os.path.join(
+        weight_directory, "{}.nc".format(uuid.uuid4())
+    )
+    to_esmf_grid(source).to_netcdf(source_temp_path)
+    to_esmf_grid(destination).to_netcdf(destination_temp_path)
+
+    command = [
+        "ESMF_RegridWeightGen",
+        "--source",
+        source_temp_path,
+        "--destination",
+        destination_temp_path,
+        "--weight",
+        weight_path,
+        "-m",
+        "conserve",
+        "-r",
+        "--netcdf4",
+        "--ignore_unmapped",
+    ]
+    if not logs:
+        command.append("--no_log")
+    if mpi:
+        command = ["mpirun", "-np", str(n_cpus)] + command
+
+    logger.info("Run: {}".format(" ".join(command)))
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError("ESMF failed to generate conservative regridding weights.") from exc
+
+    for temporary_path in (source_temp_path, destination_temp_path):
+        if os.path.exists(temporary_path):
+            logger.info("regrid successful; removing {}".format(temporary_path))
+            os.remove(temporary_path)
+
+
+def conservative_regrid(
+    source,
+    destination,
+    *,
+    weight_path,
+    max_source_cells=None,
+    n_cpus=1,
+    mpi=True,
+    logs=False,
+):
+    """Conservatively regrid a regular source dataset onto a destination grid.
+
+    Source partitions are regridded independently and their contributions are
+    summed. This is valid because ESMF conservative weights generated here
+    use destination-area normalisation and the source partitions contain
+    disjoint cells.
+
+    Parameters
+    ----------
+    source : xarray.Dataset
+        Dataset containing variables on a regular grid with one-dimensional
+        ``x`` and ``y`` coordinates and an assigned rio CRS.
+    destination : xarray.Dataset
+        Dataset defining the destination grid with one-dimensional ``x`` and
+        ``y`` coordinates and an assigned rio CRS.
+    weight_path : str or os.PathLike
+        Cache path for an unsplit weight file. Partitioned grids receive
+        ``_src_###`` before the file extension.
+    max_source_cells : int, optional
+        Maximum source cells in one ESMF invocation. Larger source grids are
+        split into disjoint contiguous y-axis partitions.
+    n_cpus : int, default=1
+        MPI process count when generating new weights.
+    mpi : bool, default=True
+        Launch ESMF through ``mpirun``.
+    logs : bool, default=False
+        Retain ESMF PET logs instead of passing ``--no_log``.
+
+    Returns
+    -------
+    xarray.Dataset
+        Conservatively regridded source variables on the destination grid.
+
+    Raises
+    ------
+    ValueError
+        If the inputs do not use compatible regular x/y grid coordinates.
+    RuntimeError
+        If ESMF cannot create a required weight file.
+    """
+    if not isinstance(source, xr.Dataset) or not isinstance(destination, xr.Dataset):
+        raise ValueError("source and destination must both be xarray.Dataset instances.")
+    source_slices = _source_y_slices(source, max_source_cells)
+    _source_y_slices(destination, None)
+
+    import xesmf as xe
+
+    result = None
+    for chunk_number, source_slice in enumerate(source_slices):
+        source_chunk = source.isel(y=source_slice)
+        chunk_weight_path = _weight_path(
+            weight_path, chunk_number, len(source_slices)
+        )
+        _generate_conservative_weights(
+            source_chunk,
+            destination,
+            weight_path=chunk_weight_path,
+            n_cpus=n_cpus,
+            mpi=mpi,
+            logs=logs,
+        )
+        regridder = xe.Regridder(
+            make_xesmf_grid(source_chunk),
+            make_xesmf_grid(destination),
+            "conservative",
+            weights=chunk_weight_path,
+            reuse_weights=True,
+        )
+        contribution = regridder(source_chunk).fillna(0)
+        result = contribution if result is None else result + contribution
+
+    result = result.assign_coords(
+        {
+            "x": destination.coords["x"].values,
+            "y": destination.coords["y"].values,
+        }
+    )
+    for variable_name in source.data_vars:
+        result[variable_name].attrs.update(source[variable_name].attrs)
+    return result

--- a/pyVPRM/lib/regridding.py
+++ b/pyVPRM/lib/regridding.py
@@ -277,6 +277,8 @@ def conservative_regrid(
             "y": destination.coords["y"].values,
         }
     )
+    result = result.rio.write_crs(destination.rio.crs)
+    result = result.rio.write_transform(destination.rio.transform(recalc=False))
     for variable_name in source.data_vars:
         result[variable_name].attrs.update(source[variable_name].attrs)
     return result

--- a/pyVPRM/sat_managers/gisa_new.py
+++ b/pyVPRM/sat_managers/gisa_new.py
@@ -1,0 +1,257 @@
+"""Load GISA-new time-of-first-imperviousness rasters."""
+
+from pathlib import Path
+from typing import Iterable, Union
+
+import numpy as np
+import rioxarray as rxr
+import xarray as xr
+from rioxarray import merge
+from rioxarray.exceptions import NoDataInBounds
+
+from pyVPRM.sat_managers.base_manager import satellite_data_manager
+
+
+class gisa_new(satellite_data_manager):
+    """Manage GISA-new 30 m impervious-surface data.
+
+    Parameters
+    ----------
+    sat_image_path : str or pathlib.Path or iterable of str or pathlib.Path
+        A GISA-new GeoTIFF, a directory containing GISA-new GeoTIFFs, or an
+        iterable of GeoTIFF paths.
+    target_year : int, default=2021
+        Year for the derived binary impervious-surface field. Pixels detected
+        as impervious on or before this year are assigned 100 percent.
+
+    Notes
+    -----
+    GISA-new pixel values record the first year in which a pixel was detected
+    as impervious: 1 corresponds to 1985 and 37 corresponds to 2021. A value
+    of 0 represents no detected impervious surface.
+    """
+
+    first_year = 1985
+    last_year = 2021
+
+    def __init__(
+        self,
+        sat_image_path: Union[str, Path, Iterable[Union[str, Path]]],
+        target_year=2021,
+    ):
+        """Initialise a GISA-new data manager.
+
+        Parameters
+        ----------
+        sat_image_path : str or pathlib.Path or iterable of str or pathlib.Path
+            GISA-new raster path or paths.
+        target_year : int, default=2021
+            Year used to derive binary impervious-surface percentages.
+
+        Raises
+        ------
+        ValueError
+            If ``target_year`` lies outside the GISA-new temporal coverage.
+        """
+        if not self.first_year <= target_year <= self.last_year:
+            raise ValueError(
+                "target_year must be between {} and {}.".format(
+                    self.first_year, self.last_year
+                )
+            )
+        super().__init__()
+        self.sat_image_path = sat_image_path
+        self.target_year = target_year
+        self.resolution = 30.0
+        self._tiles = []
+
+    def get_resolution(self):
+        """Return the nominal GISA-new spatial resolution in metres.
+
+        Returns
+        -------
+        float
+            Nominal raster resolution, 30 metres.
+        """
+        return self.resolution
+
+    def _resolve_paths(self):
+        """Resolve configured GISA-new paths to a sorted non-empty file list.
+
+        Returns
+        -------
+        list[pathlib.Path]
+            GeoTIFF paths to load.
+
+        Raises
+        ------
+        FileNotFoundError
+            If a configured path does not exist or a directory has no GeoTIFFs.
+        """
+        if isinstance(self.sat_image_path, (str, Path)):
+            configured_paths = [Path(self.sat_image_path)]
+        else:
+            configured_paths = [Path(path) for path in self.sat_image_path]
+
+        paths = []
+        for path in configured_paths:
+            if path.is_dir():
+                paths.extend(sorted(path.glob("*.tif")))
+                paths.extend(sorted(path.glob("*.tiff")))
+            elif path.is_file():
+                paths.append(path)
+            else:
+                raise FileNotFoundError(f"GISA-new path does not exist: {path}")
+
+        if not paths:
+            raise FileNotFoundError("No GISA-new GeoTIFF files were found.")
+        return paths
+
+    @staticmethod
+    def _unwrap_longitudes(image):
+        """Move negative longitudes eastward for antimeridian mosaics.
+
+        Parameters
+        ----------
+        image : xarray.Dataset
+            Geographic GISA-new tile to prepare for mosaicking.
+
+        Returns
+        -------
+        xarray.Dataset
+            Tile with negative longitudes shifted into a 0--360-degree domain.
+        """
+        x_values = image.x.values
+        if np.nanmin(x_values) >= 0.0:
+            return image
+
+        shifted_x = np.where(x_values < 0.0, x_values + 360.0, x_values)
+        image = image.assign_coords(x=shifted_x)
+        return image.rio.write_transform(image.rio.transform(recalc=True))
+
+    def _open_image(self, path):
+        """Open one GISA-new tile and derive its ISA variables.
+
+        Parameters
+        ----------
+        path : pathlib.Path
+            GeoTIFF file to open.
+
+        Returns
+        -------
+        xarray.Dataset
+            Lazy spatial data with first-detection year and binary percent
+            impervious-surface variables.
+        """
+        image = rxr.open_rasterio(
+            path,
+            band_as_variable=True,
+            masked=True,
+            mask_and_scale=False,
+            chunks={"x": 2048, "y": 2048},
+            cache=False,
+        ).squeeze(drop=True)
+        variable_name = next(iter(image.data_vars))
+        detection_index = image[variable_name]
+        first_detection_year = xr.where(
+            detection_index > 0, detection_index + self.first_year - 1, np.nan
+        )
+        imperviousness = xr.where(
+            (detection_index > 0)
+            & (detection_index <= self.target_year - self.first_year + 1),
+            100.0,
+            0.0,
+        )
+        image = image.drop_vars(variable_name)
+        image["impervious_surface_first_year"] = first_detection_year
+        image["impervious_surface_first_year"].attrs.update(
+            {
+                "long_name": "first year of impervious-surface detection",
+                "units": "year",
+                "valid_range": (self.first_year, self.last_year),
+            }
+        )
+        image["impervious_surface_percentage"] = imperviousness
+        image["impervious_surface_percentage"].attrs.update(
+            {
+                "long_name": "GISA-new binary impervious surface",
+                "units": "percent",
+                "target_year": self.target_year,
+                "valid_range": (0, 100),
+            }
+        )
+        return image
+
+    def individual_loading(self):
+        """Open configured GISA-new tiles without building a large mosaic.
+
+        Returns
+        -------
+        None
+            Lazy source tiles are assigned to :attr:`_tiles`. Call
+            :meth:`crop_to_polygon` to create :attr:`sat_img` from the
+            intersecting tiles.
+        """
+        self._tiles = [self._open_image(path) for path in self._resolve_paths()]
+        self.sat_img = None
+        self.keys = np.array(
+            ["impervious_surface_first_year", "impervious_surface_percentage"]
+        )
+
+    def crop_to_polygon(self, polygon, from_disk=False):
+        """Crop GISA-new tiles to a polygon and mosaic intersecting sources.
+
+        Parameters
+        ----------
+        polygon : geopandas.GeoDataFrame or geopandas.GeoSeries
+            Crop geometry with a defined coordinate reference system.
+        from_disk : bool, default=False
+            Retained for compatibility with the satellite-manager interface.
+            GISA-new data are windowed before clipping to avoid full-raster
+            reads regardless of this value.
+
+        Returns
+        -------
+        None
+            The cropped raster replaces :attr:`sat_img`.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`load` has not been called.
+        rioxarray.exceptions.NoDataInBounds
+            If the crop geometry does not intersect a configured tile.
+        """
+        if not self._tiles:
+            raise RuntimeError("Call load() before crop_to_polygon().")
+
+        cropped_images = []
+        for tile in self._tiles:
+            tile_polygon = polygon
+            if tile_polygon.crs != tile.rio.crs:
+                tile_polygon = tile_polygon.to_crs(tile.rio.crs)
+            try:
+                bounded_tile = tile.rio.clip_box(*tile_polygon.total_bounds)
+                cropped_images.append(
+                    bounded_tile.rio.clip(
+                        tile_polygon.geometry,
+                        all_touched=True,
+                        from_disk=False,
+                    ).squeeze()
+                )
+            except NoDataInBounds:
+                continue
+
+        if not cropped_images:
+            raise NoDataInBounds("The crop polygon does not intersect any GISA-new tile.")
+
+        all_x_values = np.concatenate([image.x.values for image in cropped_images])
+        if np.nanmax(all_x_values) - np.nanmin(all_x_values) > 180.0:
+            cropped_images = [
+                self._unwrap_longitudes(image) for image in cropped_images
+            ]
+
+        if len(cropped_images) == 1:
+            self.sat_img = cropped_images[0]
+        else:
+            self.sat_img = merge.merge_datasets(cropped_images)

--- a/tests/test_conservative_regridding.py
+++ b/tests/test_conservative_regridding.py
@@ -1,0 +1,156 @@
+"""Tests for partitioned conservative regridding utilities."""
+
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import rioxarray  # noqa: F401
+import xarray as xr
+
+from pyVPRM.lib import regridding
+
+
+def make_grid(values, *, x, y, crs="EPSG:4326"):
+    """Build a georeferenced one-variable dataset for regridding tests.
+
+    Parameters
+    ----------
+    values : numpy.ndarray
+        Two-dimensional source data with ``y, x`` dimensions.
+    x : sequence[float]
+        Grid x coordinates.
+    y : sequence[float]
+        Grid y coordinates.
+    crs : str, default="EPSG:4326"
+        Coordinate reference system assigned through rioxarray.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset containing a variable named ``value``.
+    """
+
+    return xr.Dataset(
+        {"value": (("y", "x"), values)}, coords={"x": x, "y": y}
+    ).rio.write_crs(crs)
+
+
+def test_source_y_slices_partition_without_overlap():
+    """Split an oversized source into contiguous non-overlapping strips.
+
+    Returns
+    -------
+    None
+        The test verifies a cell-limited source is partitioned by rows.
+    """
+
+    source = make_grid(np.ones((5, 4)), x=[0, 1, 2, 3], y=[0, 1, 2, 3, 4])
+
+    slices = regridding._source_y_slices(source, max_source_cells=8)
+
+    assert slices == [slice(0, 2), slice(2, 4), slice(4, 5)]
+
+
+def test_partitioned_regridding_sums_contributions_and_keeps_crs(monkeypatch, tmp_path):
+    """Sum partition contributions and retain destination spatial metadata.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace ESMF and xESMF execution.
+    tmp_path : pathlib.Path
+        Temporary directory supplied by pytest.
+
+    Returns
+    -------
+    None
+        The test verifies two partitions are generated, their contributions
+        are added, and the result retains the destination CRS and transform.
+    """
+
+    source = make_grid(
+        np.ones((4, 2)), x=[174.0, 174.1], y=[-36.3, -36.2, -36.1, -36.0]
+    )
+    destination = make_grid(
+        np.zeros((2, 2)), x=[174.0, 174.1], y=[-36.1, -36.0]
+    )
+    generated_partitions = []
+    regridder_calls = []
+
+    def capture_weight_generation(source_chunk, *args, **kwargs):
+        """Record each partition without invoking ESMF.
+
+        Parameters
+        ----------
+        source_chunk : xarray.Dataset
+            Source partition that would be passed to ESMF.
+        *args
+            Positional arguments accepted by the helper.
+        **kwargs
+            Keyword arguments accepted by the helper.
+
+        Returns
+        -------
+        None
+            The source partition is recorded for later assertions.
+        """
+
+        del args, kwargs
+        generated_partitions.append(source_chunk)
+
+    class FakeRegridder:
+        """Return one deterministic destination contribution per partition."""
+
+        def __init__(self, *args, **kwargs):
+            """Record construction order for the fake xESMF regridder.
+
+            Parameters
+            ----------
+            *args
+                Positional xESMF constructor arguments.
+            **kwargs
+                Keyword xESMF constructor arguments.
+            """
+
+            del args, kwargs
+            regridder_calls.append(len(regridder_calls) + 1)
+
+        def __call__(self, source_chunk):
+            """Return a destination-sized contribution for one partition.
+
+            Parameters
+            ----------
+            source_chunk : xarray.Dataset
+                Source partition passed by the regridding helper.
+
+            Returns
+            -------
+            xarray.Dataset
+                Constant contribution on the test destination grid.
+            """
+
+            del source_chunk
+            return xr.Dataset(
+                {"value": (("y", "x"), np.full((2, 2), regridder_calls[-1]))},
+                coords={"x": destination.x, "y": destination.y},
+            )
+
+    monkeypatch.setattr(
+        regridding, "_generate_conservative_weights", capture_weight_generation
+    )
+    monkeypatch.setattr(regridding, "make_xesmf_grid", lambda dataset: dataset)
+    monkeypatch.setitem(sys.modules, "xesmf", SimpleNamespace(Regridder=FakeRegridder))
+
+    result = regridding.conservative_regrid(
+        source,
+        destination,
+        weight_path=tmp_path / "weights.nc",
+        max_source_cells=4,
+        mpi=False,
+    )
+
+    assert [partition.sizes["y"] for partition in generated_partitions] == [2, 2]
+    assert regridder_calls == [1, 2]
+    np.testing.assert_array_equal(result["value"].values, np.full((2, 2), 3))
+    assert result.rio.crs == destination.rio.crs
+    assert result.rio.transform(recalc=False) == destination.rio.transform(recalc=False)

--- a/tests/test_impervious_surface.py
+++ b/tests/test_impervious_surface.py
@@ -1,0 +1,153 @@
+"""Tests for GISA-new ingestion and impervious-surface preprocessing."""
+
+import numpy as np
+import rasterio
+from rasterio.transform import from_origin
+import rioxarray  # noqa: F401
+import xarray as xr
+
+from pyVPRM.VPRM import vprm_preprocessor
+from pyVPRM.sat_managers.base_manager import satellite_data_manager
+from pyVPRM.sat_managers.gisa_new import gisa_new
+
+
+def write_gisa_raster(path):
+    """Write a small GISA-new-like GeoTIFF for manager tests.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Output GeoTIFF path.
+
+    Returns
+    -------
+    None
+        The raster contains no-impervious, 1985, and 2021 detection indices.
+    """
+
+    values = np.array([[0, 1], [37, 0]], dtype=np.uint8)
+    with rasterio.open(
+        path,
+        "w",
+        driver="GTiff",
+        height=2,
+        width=2,
+        count=1,
+        dtype=values.dtype,
+        crs="EPSG:4326",
+        transform=from_origin(174.0, -36.0, 0.01, 0.01),
+    ) as output:
+        output.write(values, 1)
+
+
+def test_gisa_new_derives_binary_percentages_from_detection_year(tmp_path):
+    """Convert GISA detection indices into target-year ISA percentages.
+
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Temporary directory supplied by pytest.
+
+    Returns
+    -------
+    None
+        The test verifies first-detection years and 0/100 ISA percentages.
+    """
+
+    raster_path = tmp_path / "gisa.tif"
+    write_gisa_raster(raster_path)
+    manager = gisa_new(raster_path, target_year=2021)
+
+    dataset = manager._open_image(raster_path)
+
+    np.testing.assert_allclose(
+        dataset["impervious_surface_percentage"].values,
+        [[0.0, 100.0], [100.0, 0.0]],
+    )
+    np.testing.assert_allclose(
+        dataset["impervious_surface_first_year"].values,
+        [[np.nan, 1985.0], [2021.0, np.nan]],
+        equal_nan=True,
+    )
+
+
+def test_add_impervious_surface_masks_zero_source_cells(monkeypatch, tmp_path):
+    """Exclude zero ISA cells when invoking conservative regridding.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to replace conservative regridding with capture logic.
+    tmp_path : pathlib.Path
+        Temporary directory supplied by pytest.
+
+    Returns
+    -------
+    None
+        The test verifies that the preprocessor supplies an ISA-positive mask
+        and retains the regridded manager and variable metadata.
+    """
+
+    source = xr.Dataset(
+        {
+            "impervious_surface_percentage": (
+                ("y", "x"), np.array([[0.0, 100.0], [25.0, 0.0]])
+            )
+        },
+        coords={"x": [174.0, 174.1], "y": [-36.1, -36.0]},
+    ).rio.write_crs("EPSG:4326")
+    destination = xr.Dataset(
+        coords={"x": [174.05], "y": [-36.05]}
+    ).rio.write_crs("EPSG:4326")
+    preprocessor = object.__new__(vprm_preprocessor)
+    preprocessor.n_cpus = 3
+    preprocessor.sat_imgs = satellite_data_manager(sat_img=destination)
+    captured = {}
+
+    def capture_regrid(source_dataset, destination_dataset, **kwargs):
+        """Record regridding arguments and return a one-cell result.
+
+        Parameters
+        ----------
+        source_dataset : xarray.Dataset
+            Source ISA dataset passed by the preprocessor.
+        destination_dataset : xarray.Dataset
+            Destination satellite grid passed by the preprocessor.
+        **kwargs
+            Regridding options supplied by the preprocessor.
+
+        Returns
+        -------
+        xarray.Dataset
+            One-cell percentage dataset on the destination grid.
+        """
+
+        captured["source"] = source_dataset
+        captured["destination"] = destination_dataset
+        captured.update(kwargs)
+        return xr.Dataset(
+            {"impervious_surface_percentage": (("y", "x"), [[42.0]])},
+            coords={"x": destination_dataset.x, "y": destination_dataset.y},
+        ).rio.write_crs(destination_dataset.rio.crs)
+
+    monkeypatch.setattr("pyVPRM.VPRM.conservative_regrid", capture_regrid)
+    preprocessor.add_impervious_surface_area(
+        satellite_data_manager(sat_img=source),
+        regridder_save_path=tmp_path / "weights.nc",
+        max_source_cells=100,
+        mpi=False,
+    )
+
+    np.testing.assert_array_equal(
+        captured["source_mask"].values,
+        [[False, True], [True, False]],
+    )
+    assert captured["n_cpus"] == 3
+    assert captured["max_source_cells"] == 100
+    assert captured["mpi"] is False
+    assert (
+        preprocessor.impervious_surface_area.sat_img[
+            "impervious_surface_percentage"
+        ].attrs["units"]
+        == "percent"
+    )


### PR DESCRIPTION
# Add scalable GISA-new impervious-surface preprocessing

## Summary

Add support for preparing [GISA-new](https://zenodo.org/records/14848113) impervious-surface data on a VPRM satellite grid. The implementation is designed for high-resolution sources that can exceed the practical source-grid size handled by one `ESMF_RegridWeightGen` invocation.

## What this adds

- A `gisa_new` satellite manager for GISA-new GeoTIFF tiles.
  - GISA-new values record first impervious-surface detection year as an index: 1 is 1985 and 37 is 2021.
  - The manager derives first-detection year and a target-year binary impervious-surface percentage field (0 or 100 percent).
  - It lazily opens source tiles, crops before mosaicking, and handles 180th-meridian-crossing geographic tile coordinates.
- `vprm_preprocessor.add_impervious_surface_area()`.
  - Conservatively regrids an ISA percentage field to the active satellite grid and stores it as `impervious_surface_area`.
  - Preserves ISA data when compatible preprocessors are combined into a multi-tile domain.
- General partitioned conservative-regridding utilities.
  - Split an oversized regular source grid into contiguous y-axis partitions.
  - Generate and cache one ESMF weight file per partition.
  - Sum the disjoint destination-area-normalized contributions.
  - Exclude zero ISA source cells through SCRIP `grid_imask`, reducing ESMF memory use for sparse impervious-surface products.
  - Restore the destination CRS and affine transform on the returned dataset.

## Why

For two New Zealand MODIS tiles, a full-resolution GISA-new source grid approached 391 million cells. A single ESMF weight-generation run failed near element ID 2^28 with a degenerate-element error. Splitting the source grid keeps each ESMF mesh below that practical limit while preserving conservative destination contributions. The mask is equally important because GISA is mostly zero over ocean and other non-impervious areas.

The resulting helper is intentionally general: any regular, high-resolution, sparse source field can use it when omitted source cells legitimately represent zero destination contribution.

## Example

```python
from pyVPRM.sat_managers.gisa_new import gisa_new

isa = gisa_new("/data/GISA-new", target_year=2021)
isa.load()
isa.crop_to_polygon(target_grid_polygon)

vprm_pre.add_impervious_surface_area(
    isa,
    regridder_save_path="/data/weights/gisa_to_satellite.nc",
    max_source_cells=150_000_000,
)
```

## Validation

- Added self-contained tests for GISA detection-index conversion, source-mask propagation, source partitioning and contribution summation, and destination CRS/transform preservation.
- Test suite on this branch: `4 passed`.
- The partitioning and masking approach was also exercised against full GISA source grids for all five New Zealand MODIS tiles outside this test suite.