### PR TITLE
5/8 Add polygon land-cover apportionment and ingestion

### DIFF
--- a/pyVPRM/VPRM.py
+++ b/pyVPRM/VPRM.py
@@ -724,6 +724,120 @@ class vprm_preprocessor:
                 self.land_cover_type.save(save_path)
         return
 
+    def add_fractional_land_cover_map(
+        self,
+        fractions,
+        class_mapping,
+        class_dim="land_cover_class",
+        source_name=None,
+    ):
+        """Map pre-apportioned source-class fractions to VPRM fractions.
+
+        Parameters
+        ----------
+        fractions : xarray.DataArray
+            Fractional land-cover coverage on the VPRM satellite grid. The
+            array must have dimensions ``class_dim``, ``y``, and ``x`` and
+            values from zero to one.
+        class_mapping : dict
+            Mapping from values along ``class_dim`` to integer VPRM class
+            identifiers. Contributions assigned to the same VPRM class are
+            summed.
+        class_dim : str, default="land_cover_class"
+            Dimension containing source land-cover class identifiers.
+        source_name : str, optional
+            Human-readable source product name recorded in output metadata.
+
+        Returns
+        -------
+        None
+            Mapped fractional VPRM classes are stored in
+            :attr:`land_cover_type` without regridding.
+
+        Raises
+        ------
+        TypeError
+            If ``fractions`` is not an :class:`xarray.DataArray`.
+        ValueError
+            If fractions are not on the satellite grid, lie outside the
+            fractional range, or contain unmapped source classes.
+        """
+        if not isinstance(fractions, xr.DataArray):
+            raise TypeError("fractions must be an xarray.DataArray.")
+        required_dims = {class_dim, "y", "x"}
+        if not required_dims.issubset(fractions.dims):
+            raise ValueError(
+                "fractions must contain dimensions {}.".format(
+                    ", ".join(sorted(required_dims))
+                )
+            )
+        if self.sat_imgs is None or not hasattr(self.sat_imgs, "sat_img"):
+            raise ValueError("Satellite imagery must be added before land-cover fractions.")
+
+        target_grid = self.sat_imgs.sat_img
+        for coordinate in ("x", "y"):
+            if coordinate not in target_grid.coords or not np.array_equal(
+                fractions.coords[coordinate].values,
+                target_grid.coords[coordinate].values,
+            ):
+                raise ValueError(
+                    "fractions must use the same {} coordinates as the satellite grid.".format(
+                        coordinate
+                    )
+                )
+        if fractions.rio.crs != target_grid.rio.crs:
+            raise ValueError("fractions must use the same CRS as the satellite grid.")
+
+        minimum = fractions.min(skipna=True).item()
+        maximum = fractions.max(skipna=True).item()
+        if minimum < -1e-6 or maximum > 1.0 + 1e-6:
+            raise ValueError("fractions must contain values between zero and one.")
+
+        source_classes = fractions.coords[class_dim].values.tolist()
+        missing_classes = [
+            source_class
+            for source_class in source_classes
+            if source_class not in class_mapping
+        ]
+        if missing_classes:
+            raise ValueError(
+                "class_mapping is missing source classes: {}.".format(
+                    ", ".join(str(value) for value in missing_classes)
+                )
+            )
+
+        vprm_classes = np.array(
+            sorted({int(class_mapping[source_class]) for source_class in source_classes}),
+            dtype=np.int32,
+        )
+        mapped_fractions = []
+        for vprm_class in vprm_classes:
+            source_class_values = [
+                source_class
+                for source_class in source_classes
+                if int(class_mapping[source_class]) == vprm_class
+            ]
+            mapped_fractions.append(
+                fractions.sel({class_dim: source_class_values}).sum(class_dim)
+            )
+        mapped_fractions = xr.concat(mapped_fractions, dim="vprm_classes")
+        mapped_fractions = mapped_fractions.assign_coords(vprm_classes=vprm_classes)
+        mapped_fractions.name = "vprm_fraction"
+        mapped_fractions.attrs.update(
+            {
+                "long_name": "fractional VPRM land-cover coverage",
+                "source_class_dimension": class_dim,
+            }
+        )
+        if source_name is not None:
+            mapped_fractions.attrs["source_product"] = source_name
+        mapped_fractions = mapped_fractions.rio.write_crs(target_grid.rio.crs)
+        mapped_fractions = mapped_fractions.rio.write_transform(
+            target_grid.rio.transform(recalc=False)
+        )
+        self.land_cover_type = satellite_data_manager(sat_img=mapped_fractions)
+        return
+
     def calc_min_max_evi_lswi(self):
         """
         Calculate the minimim and maximum EVI and LSWI

--- a/pyVPRM/apportion_polygons_to_grid.py
+++ b/pyVPRM/apportion_polygons_to_grid.py
@@ -185,8 +185,11 @@ def apportion(
         cells = _target_cell_chunk(
             x_edges, y_edges, row_start, row_stop, target_grid.rio.crs
         )
+        if cells.empty:
+            continue
+        cells_in_source_crs = cells.to_crs(source.crs)
         candidate_indices = source_index.query(
-            box(*cells.total_bounds), predicate="intersects"
+            box(*cells_in_source_crs.total_bounds), predicate="intersects"
         )
         if len(candidate_indices) == 0:
             continue

--- a/pyVPRM/apportion_polygons_to_grid.py
+++ b/pyVPRM/apportion_polygons_to_grid.py
@@ -12,6 +12,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import rioxarray  # noqa: F401
+from rasterio.features import rasterize
 import xarray as xr
 from shapely.geometry import box
 
@@ -55,7 +56,7 @@ def _coordinate_edges(coordinates, name):
     )
 
 
-def _target_cell_chunk(x_edges, y_edges, row_start, row_stop, crs):
+def _target_cell_chunk(x_edges, y_edges, row_start, row_stop, crs, coverage_mask):
     """Build one row-wise chunk of target-grid cell polygons.
 
     Parameters
@@ -66,24 +67,21 @@ def _target_cell_chunk(x_edges, y_edges, row_start, row_stop, crs):
         Half-open range of target-grid rows included in the chunk.
     crs : pyproj.CRS or str
         CRS of the target grid.
+    coverage_mask : numpy.ndarray
+        Boolean ``y, x`` mask selecting cells that could overlap an input
+        polygon.
 
     Returns
     -------
     geopandas.GeoDataFrame
         Cell polygons with ``_row`` and ``_column`` index columns.
     """
-    row_indices = np.repeat(np.arange(row_start, row_stop), len(x_edges) - 1)
-    column_indices = np.tile(np.arange(len(x_edges) - 1), row_stop - row_start)
-    lower_x = np.tile(x_edges[:-1], row_stop - row_start)
-    upper_x = np.tile(x_edges[1:], row_stop - row_start)
-    lower_y = np.repeat(
-        np.minimum(y_edges[row_start:row_stop], y_edges[row_start + 1 : row_stop + 1]),
-        len(x_edges) - 1,
-    )
-    upper_y = np.repeat(
-        np.maximum(y_edges[row_start:row_stop], y_edges[row_start + 1 : row_stop + 1]),
-        len(x_edges) - 1,
-    )
+    local_rows, column_indices = np.nonzero(coverage_mask[row_start:row_stop])
+    row_indices = row_start + local_rows
+    lower_x = x_edges[column_indices]
+    upper_x = x_edges[column_indices + 1]
+    lower_y = np.minimum(y_edges[row_indices], y_edges[row_indices + 1])
+    upper_y = np.maximum(y_edges[row_indices], y_edges[row_indices + 1])
 
     return gpd.GeoDataFrame(
         {"_row": row_indices, "_column": column_indices},
@@ -93,6 +91,44 @@ def _target_cell_chunk(x_edges, y_edges, row_start, row_stop, crs):
         ],
         crs=crs,
     )
+
+
+def _polygon_coverage_mask(polygons, target_grid):
+    """Rasterize a conservative mask of target cells touched by polygons.
+
+    Parameters
+    ----------
+    polygons : geopandas.GeoDataFrame
+        Input polygon features with a defined CRS.
+    target_grid : xarray.Dataset or xarray.DataArray
+        Regular target grid with rio CRS metadata and an affine transform.
+
+    Returns
+    -------
+    numpy.ndarray
+        Boolean ``y, x`` mask. A true cell is touched by at least one input
+        polygon and therefore needs an exact vector-area calculation.
+
+    Notes
+    -----
+    ``all_touched=True`` deliberately over-selects boundary cells, ensuring
+    that a partial overlap is never lost during this inexpensive prefilter.
+    """
+    polygons_on_target_grid = polygons.to_crs(target_grid.rio.crs)
+    shapes = (
+        (geometry, 1)
+        for geometry in polygons_on_target_grid.geometry
+        if geometry is not None and not geometry.is_empty
+    )
+    return rasterize(
+        shapes,
+        out_shape=(target_grid.sizes["y"], target_grid.sizes["x"]),
+        transform=target_grid.rio.transform(recalc=False),
+        all_touched=True,
+        fill=0,
+        default_value=1,
+        dtype="uint8",
+    ).astype(bool)
 
 
 def apportion(
@@ -179,11 +215,17 @@ def apportion(
     y_edges = _coordinate_edges(y_values, "y")
     fractions = np.zeros((len(class_values), len(y_values), len(x_values)), dtype=dtype)
     source_index = source.sindex
+    coverage_mask = _polygon_coverage_mask(source, target_grid)
 
     for row_start in range(0, len(y_values), chunk_rows):
         row_stop = min(row_start + chunk_rows, len(y_values))
         cells = _target_cell_chunk(
-            x_edges, y_edges, row_start, row_stop, target_grid.rio.crs
+            x_edges,
+            y_edges,
+            row_start,
+            row_stop,
+            target_grid.rio.crs,
+            coverage_mask,
         )
         if cells.empty:
             continue

--- a/pyVPRM/apportion_polygons_to_grid.py
+++ b/pyVPRM/apportion_polygons_to_grid.py
@@ -1,0 +1,246 @@
+"""Apportion polygon classes onto a regular raster grid.
+
+Notes
+-----
+Areas are calculated after both input geometries have been transformed to an
+equal-area CRS supplied by the caller.  The returned fractions retain the
+coordinates and spatial metadata of the target grid; the area CRS is used
+only for the intersection calculation.
+"""
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import rioxarray  # noqa: F401
+import xarray as xr
+from shapely.geometry import box
+
+
+def _coordinate_edges(coordinates, name):
+    """Return pixel edges inferred from regularly spaced center coordinates.
+
+    Parameters
+    ----------
+    coordinates : numpy.ndarray
+        One-dimensional pixel-center coordinates.
+    name : str
+        Coordinate name used in validation error messages.
+
+    Returns
+    -------
+    numpy.ndarray
+        One-dimensional array with one more element than ``coordinates``.
+
+    Raises
+    ------
+    ValueError
+        If fewer than two coordinates are supplied or their spacing is not
+        regular.
+    """
+    coordinates = np.asarray(coordinates)
+    if coordinates.ndim != 1 or coordinates.size < 2:
+        raise ValueError(f"{name!r} must contain at least two coordinates.")
+
+    steps = np.diff(coordinates)
+    if not np.allclose(steps, steps[0]):
+        raise ValueError(f"{name!r} coordinates must be regularly spaced.")
+
+    half_step = steps[0] / 2
+    return np.concatenate(
+        (
+            [coordinates[0] - half_step],
+            coordinates[:-1] + np.diff(coordinates) / 2,
+            [coordinates[-1] + half_step],
+        )
+    )
+
+
+def _target_cell_chunk(x_edges, y_edges, row_start, row_stop, crs):
+    """Build one row-wise chunk of target-grid cell polygons.
+
+    Parameters
+    ----------
+    x_edges, y_edges : numpy.ndarray
+        Pixel-edge coordinates for the target grid.
+    row_start, row_stop : int
+        Half-open range of target-grid rows included in the chunk.
+    crs : pyproj.CRS or str
+        CRS of the target grid.
+
+    Returns
+    -------
+    geopandas.GeoDataFrame
+        Cell polygons with ``_row`` and ``_column`` index columns.
+    """
+    row_indices = np.repeat(np.arange(row_start, row_stop), len(x_edges) - 1)
+    column_indices = np.tile(np.arange(len(x_edges) - 1), row_stop - row_start)
+    lower_x = np.tile(x_edges[:-1], row_stop - row_start)
+    upper_x = np.tile(x_edges[1:], row_stop - row_start)
+    lower_y = np.repeat(
+        np.minimum(y_edges[row_start:row_stop], y_edges[row_start + 1 : row_stop + 1]),
+        len(x_edges) - 1,
+    )
+    upper_y = np.repeat(
+        np.maximum(y_edges[row_start:row_stop], y_edges[row_start + 1 : row_stop + 1]),
+        len(x_edges) - 1,
+    )
+
+    return gpd.GeoDataFrame(
+        {"_row": row_indices, "_column": column_indices},
+        geometry=[
+            box(min_x, min_y, max_x, max_y)
+            for min_x, min_y, max_x, max_y in zip(lower_x, lower_y, upper_x, upper_y)
+        ],
+        crs=crs,
+    )
+
+
+def apportion(
+    polygons,
+    target_grid,
+    area_crs,
+    class_column="vprm_class",
+    *,
+    class_dim="land_cover_class",
+    chunk_rows=128,
+    dtype=np.float32,
+):
+    """Calculate per-class polygon coverage fractions for a regular grid.
+
+    Parameters
+    ----------
+    polygons : geopandas.GeoDataFrame
+        Polygon features with a defined CRS and a categorical ``class_column``.
+        Features with a missing class value are ignored.
+    target_grid : xarray.Dataset or xarray.DataArray
+        Regular grid with one-dimensional ``x`` and ``y`` coordinates and rio
+        CRS metadata.  Fractions are returned on these original coordinates.
+    area_crs : str, int, or pyproj.CRS
+        Equal-area CRS appropriate to the region.  This must be supplied by
+        the caller; it is used only to measure cell and intersection areas.
+    class_column : str, default="vprm_class"
+        Column in ``polygons`` containing the categorical class values.
+    class_dim : str, default="land_cover_class"
+        Name of the class dimension in the returned array.
+    chunk_rows : int, default=128
+        Number of target-grid rows to intersect at a time.  Smaller chunks
+        reduce peak memory use at the cost of more spatial-index queries.
+    dtype : numpy.dtype, default=numpy.float32
+        Data type used for the returned coverage fractions.
+
+    Returns
+    -------
+    xarray.DataArray
+        Fractional class coverage with dimensions ``(class_dim, y, x)``.  Its
+        rio CRS and affine transform match ``target_grid``.
+
+    Raises
+    ------
+    TypeError
+        If ``polygons`` is not a GeoDataFrame.
+    ValueError
+        If required spatial metadata, coordinates, or class values are
+        absent, or if ``chunk_rows`` is not positive.
+
+    Notes
+    -----
+    Fractions are intersection area divided by the complete target-cell area,
+    not by the mapped polygon area.  Therefore cells partly outside the input
+    polygon coverage retain a fractional sum below one.
+    """
+    if not isinstance(polygons, gpd.GeoDataFrame):
+        raise TypeError("polygons must be a geopandas.GeoDataFrame.")
+    if polygons.crs is None:
+        raise ValueError("polygons must have a defined CRS.")
+    if class_column not in polygons.columns:
+        raise ValueError(f"polygons do not contain class column {class_column!r}.")
+    if chunk_rows <= 0:
+        raise ValueError("chunk_rows must be a positive integer.")
+    if "x" not in target_grid.coords or "y" not in target_grid.coords:
+        raise ValueError(
+            "target_grid must have one-dimensional 'x' and 'y' coordinates."
+        )
+    if target_grid.coords["x"].ndim != 1 or target_grid.coords["y"].ndim != 1:
+        raise ValueError("target_grid 'x' and 'y' coordinates must be one-dimensional.")
+    if target_grid.rio.crs is None:
+        raise ValueError("target_grid must have rio CRS metadata.")
+
+    source = polygons.loc[
+        polygons[class_column].notna(), [class_column, "geometry"]
+    ].copy()
+    if source.empty:
+        raise ValueError("polygons contain no non-null class values.")
+
+    class_values = list(pd.unique(source[class_column]))
+    class_positions = {value: index for index, value in enumerate(class_values)}
+    x_values = target_grid.coords["x"].values
+    y_values = target_grid.coords["y"].values
+    x_edges = _coordinate_edges(x_values, "x")
+    y_edges = _coordinate_edges(y_values, "y")
+    fractions = np.zeros((len(class_values), len(y_values), len(x_values)), dtype=dtype)
+    source_index = source.sindex
+
+    for row_start in range(0, len(y_values), chunk_rows):
+        row_stop = min(row_start + chunk_rows, len(y_values))
+        cells = _target_cell_chunk(
+            x_edges, y_edges, row_start, row_stop, target_grid.rio.crs
+        )
+        candidate_indices = source_index.query(
+            box(*cells.total_bounds), predicate="intersects"
+        )
+        if len(candidate_indices) == 0:
+            continue
+
+        cells = cells.to_crs(area_crs)
+        cells["_cell_area"] = cells.geometry.area
+        candidates = source.iloc[candidate_indices].to_crs(area_crs)
+        intersections = gpd.overlay(
+            cells, candidates, how="intersection", keep_geom_type=False
+        )
+        if intersections.empty:
+            continue
+
+        intersections["_intersection_area"] = intersections.geometry.area
+        intersections = intersections.loc[
+            intersections["_intersection_area"] > 0
+        ].copy()
+        if intersections.empty:
+            continue
+        grouped = (
+            intersections.groupby(["_row", "_column", class_column], sort=False)[
+                "_intersection_area"
+            ]
+            .sum()
+            .reset_index()
+            .merge(
+                cells[["_row", "_column", "_cell_area"]],
+                on=["_row", "_column"],
+                how="left",
+                validate="many_to_one",
+            )
+        )
+        for class_value, class_group in grouped.groupby(class_column, sort=False):
+            fractions[
+                class_positions[class_value],
+                class_group["_row"].to_numpy(),
+                class_group["_column"].to_numpy(),
+            ] = (
+                class_group["_intersection_area"].to_numpy()
+                / class_group["_cell_area"].to_numpy()
+            )
+
+    result = xr.DataArray(
+        fractions,
+        dims=(class_dim, "y", "x"),
+        coords={class_dim: class_values, "y": y_values, "x": x_values},
+        name="fraction",
+        attrs={
+            "long_name": "fractional polygon-class coverage",
+            "units": "1",
+            "class_column": class_column,
+            "area_crs": str(area_crs),
+        },
+    )
+    result = result.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    result = result.rio.write_crs(target_grid.rio.crs)
+    return result.rio.write_transform(target_grid.rio.transform(recalc=False))

--- a/tests/test_apportion_polygons_to_grid.py
+++ b/tests/test_apportion_polygons_to_grid.py
@@ -46,3 +46,40 @@ def test_apportion_preserves_fractional_class_coverage():
         fractions.sel(land_cover_class=2), [[0.0, 0.5], [0.0, 0.0]]
     )
     assert fractions.rio.crs.to_epsg() == 2193
+
+
+def test_apportion_queries_polygons_in_their_own_crs():
+    """Find polygon candidates when source and target grids use different CRSs.
+
+    Returns
+    -------
+    None
+        The test asserts that a polygon matching one target cell contributes
+        full coverage after source-CRS spatial-index selection.
+    """
+    target_grid = xr.DataArray(
+        np.zeros((2, 2)),
+        dims=("y", "x"),
+        coords={"y": [-43.005, -43.015], "x": [172.005, 172.015]},
+    )
+    target_grid = target_grid.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    target_grid = target_grid.rio.write_crs("EPSG:4326")
+    target_grid = target_grid.rio.write_transform()
+    source_polygon = gpd.GeoDataFrame(
+        {"lcdb_class": [1]},
+        geometry=[box(172.0, -43.01, 172.01, -43.0)],
+        crs="EPSG:4326",
+    ).to_crs("EPSG:2193")
+
+    fractions = apportion(
+        source_polygon,
+        target_grid,
+        "EPSG:2193",
+        class_column="lcdb_class",
+        chunk_rows=1,
+    )
+
+    np.testing.assert_allclose(
+        fractions.sel(land_cover_class=1).isel(y=0, x=0), 1.0, rtol=1e-6
+    )
+    np.testing.assert_allclose(fractions.sum(), 1.0, rtol=1e-6)

--- a/tests/test_apportion_polygons_to_grid.py
+++ b/tests/test_apportion_polygons_to_grid.py
@@ -1,0 +1,48 @@
+"""Tests for polygon-to-grid fractional coverage apportionment."""
+
+import geopandas as gpd
+import numpy as np
+import rioxarray  # noqa: F401
+import xarray as xr
+from shapely.geometry import box
+
+from pyVPRM.apportion_polygons_to_grid import apportion
+
+
+def test_apportion_preserves_fractional_class_coverage():
+    """Apportion full and partial polygons onto a two-cell target grid.
+
+    Returns
+    -------
+    None
+        The test asserts expected class fractions and spatial metadata.
+    """
+    target_grid = xr.DataArray(
+        np.zeros((2, 2)),
+        dims=("y", "x"),
+        coords={"y": [500.0, 1500.0], "x": [500.0, 1500.0]},
+    )
+    target_grid = target_grid.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    target_grid = target_grid.rio.write_crs("EPSG:2193")
+    target_grid = target_grid.rio.write_transform()
+    polygons = gpd.GeoDataFrame(
+        {"lcdb_class": [1, 2]},
+        geometry=[box(0, 0, 1000, 1000), box(1000, 0, 1500, 1000)],
+        crs="EPSG:2193",
+    )
+
+    fractions = apportion(
+        polygons,
+        target_grid,
+        "EPSG:2193",
+        class_column="lcdb_class",
+        chunk_rows=1,
+    )
+
+    np.testing.assert_allclose(
+        fractions.sel(land_cover_class=1), [[1.0, 0.0], [0.0, 0.0]]
+    )
+    np.testing.assert_allclose(
+        fractions.sel(land_cover_class=2), [[0.0, 0.5], [0.0, 0.0]]
+    )
+    assert fractions.rio.crs.to_epsg() == 2193

--- a/tests/test_fractional_land_cover.py
+++ b/tests/test_fractional_land_cover.py
@@ -1,0 +1,98 @@
+"""Tests for ingesting pre-apportioned fractional land cover."""
+
+import numpy as np
+import rioxarray  # noqa: F401
+import xarray as xr
+
+from pyVPRM.VPRM import vprm_preprocessor
+from pyVPRM.sat_managers.base_manager import satellite_data_manager
+
+
+def make_preprocessor_with_grid():
+    """Build a minimal preprocessor with an EPSG:2193 satellite grid.
+
+    Returns
+    -------
+    vprm_preprocessor
+        Preprocessor instance with a two-by-two satellite grid.
+    """
+    grid = xr.Dataset(coords={"y": [200.0, 100.0], "x": [100.0, 200.0]})
+    grid = grid.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    grid = grid.rio.write_crs("EPSG:2193")
+    grid = grid.rio.write_transform()
+    preprocessor = object.__new__(vprm_preprocessor)
+    preprocessor.sat_imgs = satellite_data_manager(sat_img=grid)
+    preprocessor.land_cover_type = None
+    return preprocessor
+
+
+def make_source_fractions():
+    """Build source-class fractions on the test satellite grid.
+
+    Returns
+    -------
+    xarray.DataArray
+        Three source-class fractions with ``land_cover_class``, ``y``, and
+        ``x`` dimensions and EPSG:2193 spatial metadata.
+    """
+    fractions = xr.DataArray(
+        np.array(
+            [
+                [[0.2, 0.0], [0.5, 0.0]],
+                [[0.3, 1.0], [0.0, 0.0]],
+                [[0.5, 0.0], [0.5, 1.0]],
+            ]
+        ),
+        dims=("land_cover_class", "y", "x"),
+        coords={
+            "land_cover_class": [10, 20, 30],
+            "y": [200.0, 100.0],
+            "x": [100.0, 200.0],
+        },
+    )
+    fractions = fractions.rio.set_spatial_dims(x_dim="x", y_dim="y")
+    fractions = fractions.rio.write_crs("EPSG:2193")
+    return fractions.rio.write_transform()
+
+
+def test_add_fractional_land_cover_map_aggregates_classes():
+    """Aggregate multiple source classes into one VPRM class.
+
+    Returns
+    -------
+    None
+        The test verifies source-class aggregation and retained CRS metadata.
+    """
+    preprocessor = make_preprocessor_with_grid()
+    preprocessor.add_fractional_land_cover_map(
+        make_source_fractions(),
+        {10: 1, 20: 1, 30: 8},
+        source_name="synthetic",
+    )
+
+    result = preprocessor.land_cover_type.sat_img
+    np.testing.assert_array_equal(result.vprm_classes.values, [1, 8])
+    np.testing.assert_allclose(result.sel(vprm_classes=1), [[0.5, 1.0], [0.5, 0.0]])
+    np.testing.assert_allclose(result.sel(vprm_classes=8), [[0.5, 0.0], [0.5, 1.0]])
+    assert result.rio.crs.to_epsg() == 2193
+    assert result.attrs["source_product"] == "synthetic"
+
+
+def test_add_fractional_land_cover_map_rejects_unmapped_classes():
+    """Require every source class to have an explicit VPRM mapping.
+
+    Returns
+    -------
+    None
+        The test verifies an incomplete class mapping raises ``ValueError``.
+    """
+    preprocessor = make_preprocessor_with_grid()
+
+    try:
+        preprocessor.add_fractional_land_cover_map(
+            make_source_fractions(), {10: 1, 20: 1}
+        )
+    except ValueError as error:
+        assert "missing source classes" in str(error)
+    else:
+        raise AssertionError("Expected an incomplete class mapping to fail.")


### PR DESCRIPTION
# Add polygon land-cover apportionment and ingestion

## Summary

Add a generic path for using polygon-native land-cover products with pyVPRM. The new utility calculates fractional source-class coverage for each cell of an existing regular satellite grid. A companion preprocessor method maps those already-grid-aligned source fractions to VPRM classes without regridding them again.

## Existing fractional land-cover workflow

pyVPRM already supports fractional VPRM land cover from a categorical raster: `add_land_cover_map()` maps source pixels to VPRM classes, creates a binary layer for each resulting class, and conservatively regrids those layers to the satellite grid.

This PR does not replace that workflow. It adds the corresponding input path for products that begin as vector polygons, or for fractions computed by an external geometric workflow.

## What this adds

- `pyVPRM.apportion_polygons_to_grid.apportion()`.
  - Intersects classified source polygons with regular target-grid cell polygons and returns class × y × x fractional coverage.
  - Requires the caller to provide an equal-area CRS for area calculations; no region-specific CRS is assumed.
  - Processes target rows in chunks and uses a conservative rasterized footprint prefilter, avoiding expensive intersection work for cells that cannot overlap any source polygon.
  - Transforms target-cell bounds to the source polygon CRS before spatial index queries, which is necessary when the source and target use different CRSs.
  - Retains the original target-grid coordinates, CRS, and affine transform.
- `vprm_preprocessor.add_fractional_land_cover_map()`.
  - Accepts source-class fractions already aligned with the active satellite grid.
  - Validates coordinates, CRS, fraction bounds, and complete source-class mappings.
  - Maps source classes to VPRM classes and sums contributions when several source classes share a VPRM class.
  - Does not perform another regridding operation.

## Example

```python
from pyVPRM.apportion_polygons_to_grid import apportion

fractions = apportion(
    land_cover_polygons,
    satellite_grid,
    area_crs="EPSG:6933",
    class_column="land_cover_class",
)

vprm_pre.add_fractional_land_cover_map(
    fractions,
    class_mapping={10: 1, 20: 1, 30: 8},
    source_name="example polygon land cover",
)
```

## Validation

- Tests cover full and partial polygon coverage, preservation of fractional coverage and CRS metadata, mixed-CRS spatial-index queries, mapping and aggregation of source classes, and rejection of incomplete class mappings.
- Focused test suite on this branch: `4 passed`.
- The approach was also applied outside this test suite to New Zealand LCDB polygons on five MODIS grids.
