### PR TITLE
6/8 Use the published VPRM W_scale for every class

### DIFF
--- a/pyVPRM/vprm_models/vprm_base_model.py
+++ b/pyVPRM/vprm_models/vprm_base_model.py
@@ -156,14 +156,30 @@ class vprm_base_model:
         return ret
 
     def get_w_scale(self, lon=None, lat=None, site_name=None, land_cover_type=None):
-        """
-        Get VPRM w_scale
+        """Calculate the VPRM water scalar from LSWI.
 
-            Parameters:
-                    lon (float): longitude
-                    lat (float): latitude
-            Returns:
-                    w_scale array
+        Parameters
+        ----------
+        lon : float, optional
+            Longitude of a requested point.
+        lat : float, optional
+            Latitude of a requested point.
+        site_name : str, optional
+            Flux-tower site name for point-based evaluation.
+        land_cover_type : int, optional
+            VPRM land-cover class. Retained for API compatibility; the
+            published water-scalar form is used for every class.
+
+        Returns
+        -------
+        float or xarray.DataArray
+            Water scalar ``(1 + LSWI) / (1 + max_LSWI)``.
+
+        Notes
+        -----
+        This is the form given in Mahadevan et al. (2008), Eq. 8. It avoids
+        division by a near-zero annual LSWI range in the former class-specific
+        alternative.
         """
 
         # if (self.new is False) & ('w_scale' in self.buffer.keys()):
@@ -213,11 +229,7 @@ class vprm_base_model:
             diff = max_lswi - min_lswi
             diff = xr.where(diff < 0.01, 0.01, diff)
 
-        # Doesn't show any improvements, but increases instability
-        if land_cover_type in [4, 7]:
-            self.buffer["w_scale"] = (lswi - min_lswi) / (max_lswi - min_lswi)
-        else:
-            self.buffer["w_scale"] = (1 + lswi) / (1 + max_lswi)
+        self.buffer["w_scale"] = (1 + lswi) / (1 + max_lswi)
         return self.buffer["w_scale"]
 
     def get_evi(self, lon=None, lat=None, site_name=None):

--- a/tests/test_w_scale.py
+++ b/tests/test_w_scale.py
@@ -1,0 +1,32 @@
+"""Tests for the VPRM water-scalar calculation."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import xarray as xr
+
+from pyVPRM.vprm_models.vprm_base_model import vprm_base_model
+
+
+def test_get_w_scale_uses_published_formula_for_every_class():
+    """Use the stable published water scalar for a former special-case class.
+
+    Returns
+    -------
+    None
+        The test verifies the formula remains finite even when annual LSWI
+        extrema differ by only a tiny amount.
+    """
+    model = object.__new__(vprm_base_model)
+    model.buffer = {}
+    model.get_lswi = lambda lon, lat, site_name: xr.DataArray([[0.15]])
+    model.vprm_pre = SimpleNamespace(
+        max_lswi=SimpleNamespace(sat_img={"max_lswi": xr.DataArray([[0.150001]])}),
+        min_lswi=SimpleNamespace(sat_img={"min_lswi": xr.DataArray([[0.15]])}),
+    )
+
+    result = model.get_w_scale(land_cover_type=4)
+
+    expected = (1.0 + 0.15) / (1.0 + 0.150001)
+    np.testing.assert_allclose(result, expected)
+    assert np.isfinite(result).all()


### PR DESCRIPTION
# Use the published VPRM W_scale for every class

## Summary

Use the W_scale formulation from [Mahadevan et al. (2008)](https://doi.org/10.1029/2006GB002735), Eq. 8, for all VPRM land-cover classes:

```text
W_scale = (1 + LSWI) / (1 + max_LSWI)
```

## Problem

`vprm_base_model.get_w_scale()` previously used a different expression for classes 4 and 7:

```text
(LSWI - min_LSWI) / (max_LSWI - min_LSWI)
```

That denominator can become extremely small where the annual LSWI range is small (i.e. max_LSWI and min_LSWI are close to one another), producing very large or non-finite W_scale values. This happened frequently in grassland and shrubland cells during New Zealand runs.

## Change

- Apply the published Eq. 8 form consistently to every class.
- Retain `land_cover_type` in the method signature for API compatibility.
- Document the scientific rationale in the method docstring.
- Add a regression test using a former special-case class with nearly equal annual LSWI extrema; it verifies the result is finite and matches Eq. 8.

## Validation

tests/test_w_scale.py: 1 passed
full discovered test suite on this branch: 1 passed

