### PR TITLE
7/8 Add UrbanVPRM model and reference-EVI preprocessing

### DIFF
--- a/pyVPRM/urban_vprm_preprocessor.py
+++ b/pyVPRM/urban_vprm_preprocessor.py
@@ -1,0 +1,171 @@
+"""Prepare ISA and reference-EVI inputs for UrbanVPRM."""
+
+import numpy as np
+import scipy
+import xarray as xr
+
+from pyVPRM.VPRM import vprm_preprocessor
+from pyVPRM.sat_managers.base_manager import satellite_data_manager
+
+
+class urban_vprm_preprocessor(vprm_preprocessor):
+    """Extend VPRM preprocessing with static UrbanVPRM ancillary inputs.
+
+    Notes
+    -----
+    This subclass retains the generic VPRM satellite and land-cover workflow.
+    It adds only static, urban-specific fields that depend on impervious
+    surface area, fractional land cover, and the satellite grid.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize generic VPRM preprocessing and UrbanVPRM state.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments accepted by :class:`vprm_preprocessor`.
+        **kwargs
+            Keyword arguments accepted by :class:`vprm_preprocessor`.
+        """
+        super().__init__(*args, **kwargs)
+        self.impervious_surface_area = None
+        self.urban_reference_evi = None
+
+    def add_urban_reference_evi_lookup(
+        self,
+        vegetated_vprm_classes,
+        isa_variable="impervious_surface_percentage",
+        zero_tolerance=1e-6,
+    ):
+        """Build nearest-reference EVI indices for the UrbanVPRM model.
+
+        The static lookup identifies, for each satellite-grid cell, the nearest
+        vegetated cell with zero impervious surface. UrbanVPRM can use these
+        static candidates directly or search them dynamically for positive
+        EVI at the current satellite composite.
+
+        Parameters
+        ----------
+        vegetated_vprm_classes : iterable of int
+            VPRM classes eligible to provide an EVI reference. Water and other
+            non-vegetated classes must not be included.
+        isa_variable : str, default="impervious_surface_percentage"
+            Impervious-surface percentage variable supplied on the satellite
+            grid by a compatible preprocessing workflow.
+        zero_tolerance : float, default=1e-6
+            Absolute tolerance used to identify ISA-zero reference cells.
+
+        Returns
+        -------
+        None
+            A satellite-grid dataset containing nearest-reference ``y`` and
+            ``x`` indices, distance in grid units, and the eligible-reference
+            mask is stored in :attr:`urban_reference_evi`.
+
+        Raises
+        ------
+        ValueError
+            If ISA or fractional land cover has not been added, requested VPRM
+            classes are unavailable, or no eligible reference cell exists.
+        """
+        if self.impervious_surface_area is None:
+            raise ValueError("Impervious-surface data must be added first.")
+        if self.land_cover_type is None:
+            raise ValueError("Fractional land-cover data must be added first.")
+        if isa_variable not in self.impervious_surface_area.sat_img:
+            raise ValueError(
+                "Impervious-surface data do not contain {!r}.".format(isa_variable)
+            )
+
+        land_cover = self.land_cover_type.sat_img
+        if "vprm_classes" not in land_cover.dims:
+            raise ValueError("Land-cover data must have a vprm_classes dimension.")
+        vegetated_vprm_classes = np.asarray(vegetated_vprm_classes, dtype=np.int32)
+        available_classes = land_cover.coords["vprm_classes"].values
+        missing_classes = np.setdiff1d(vegetated_vprm_classes, available_classes)
+        if missing_classes.size:
+            raise ValueError(
+                "Vegetated VPRM classes are unavailable: {}.".format(
+                    ", ".join(str(value) for value in missing_classes)
+                )
+            )
+
+        isa = self.impervious_surface_area.sat_img[isa_variable]
+        if not np.array_equal(isa.x.values, land_cover.x.values) or not np.array_equal(
+            isa.y.values, land_cover.y.values
+        ):
+            raise ValueError("ISA and land-cover data must use the same grid coordinates.")
+        if isa.rio.crs != land_cover.rio.crs:
+            raise ValueError("ISA and land-cover data must use the same CRS.")
+
+        vegetated_fraction = land_cover.sel(
+            vprm_classes=vegetated_vprm_classes
+        ).sum("vprm_classes")
+        eligible_reference = (
+            np.isfinite(isa)
+            & np.isclose(isa, 0.0, atol=zero_tolerance)
+            & (vegetated_fraction > 0.0)
+        )
+        eligible_values = np.asarray(eligible_reference.values, dtype=bool)
+        if not eligible_values.any():
+            raise ValueError("No vegetated ISA-zero reference cells are available.")
+
+        y_resolution = np.abs(np.diff(isa.y.values)).mean()
+        x_resolution = np.abs(np.diff(isa.x.values)).mean()
+        distances, nearest_indices = scipy.ndimage.distance_transform_edt(
+            ~eligible_values,
+            sampling=(y_resolution, x_resolution),
+            return_indices=True,
+        )
+        annual_evi = getattr(self, "min_max_evi", None)
+        if annual_evi is not None and {
+            "min_evi", "max_evi"
+        }.issubset(annual_evi.sat_img.data_vars):
+            minimum_evi = annual_evi.sat_img["min_evi"]
+            maximum_evi = annual_evi.sat_img["max_evi"]
+            reference_maximum_evi = np.asarray(maximum_evi.values)[
+                nearest_indices[0], nearest_indices[1]
+            ]
+            reference_minimum_evi = np.asarray(minimum_evi.values)[
+                nearest_indices[0], nearest_indices[1]
+            ]
+        else:
+            reference_maximum_evi = np.full(isa.shape, np.nan, dtype=np.float32)
+            reference_minimum_evi = np.full(isa.shape, np.nan, dtype=np.float32)
+        lookup = xr.Dataset(
+            {
+                "reference_y_index": (("y", "x"), nearest_indices[0].astype(np.int32)),
+                "reference_x_index": (("y", "x"), nearest_indices[1].astype(np.int32)),
+                "reference_distance": (("y", "x"), distances.astype(np.float32)),
+                "reference_eligible": (("y", "x"), eligible_values),
+                "reference_maximum_evi": (
+                    ("y", "x"), reference_maximum_evi.astype(np.float32)
+                ),
+                "reference_minimum_evi": (
+                    ("y", "x"), reference_minimum_evi.astype(np.float32)
+                ),
+            },
+            coords={"y": isa.y, "x": isa.x},
+        )
+        lookup["reference_distance"].attrs.update(
+            {
+                "long_name": "distance to nearest vegetated zero-impervious reference cell",
+                "units": "metre",
+            }
+        )
+        lookup["reference_maximum_evi"].attrs["long_name"] = (
+            "annual maximum EVI at selected UrbanVPRM reference cell"
+        )
+        lookup["reference_minimum_evi"].attrs["long_name"] = (
+            "annual minimum EVI at selected UrbanVPRM reference cell"
+        )
+        lookup.attrs["vegetated_vprm_classes"] = ",".join(
+            str(value) for value in vegetated_vprm_classes
+        )
+        lookup.attrs["reference_candidate_definition"] = (
+            "zero ISA and positive fractional coverage of an eligible vegetated VPRM class"
+        )
+        lookup = lookup.rio.write_crs(isa.rio.crs)
+        lookup = lookup.rio.write_transform(isa.rio.transform(recalc=False))
+        self.urban_reference_evi = satellite_data_manager(sat_img=lookup)

--- a/pyVPRM/vprm_models/vprm_base_model.py
+++ b/pyVPRM/vprm_models/vprm_base_model.py
@@ -393,6 +393,73 @@ class vprm_base_model:
                     ret_dict[i] = self.era5_inst.get_data(key=i).values.flatten()
         return ret_dict
 
+    def _calculate_gpp(self, land_cover_fraction, land_cover_type, inputs):
+        """Calculate base-VPRM gross primary production for one class.
+
+        Parameters
+        ----------
+        land_cover_fraction : float, pandas.Series, or xarray.DataArray
+            Fractional coverage of ``land_cover_type`` on the prediction grid.
+        land_cover_type : int
+            VPRM class identifier whose fitted parameters are used.
+        inputs : dict
+            VPRM driver fields containing ``Ps``, ``Ws``, ``Ts``, ``evi``, and
+            ``par``.
+
+        Returns
+        -------
+        float, pandas.Series, or xarray.DataArray
+            Gross primary production for the requested VPRM class.
+
+        Notes
+        -----
+        Subclasses may override this hook while retaining the shared class loop
+        and output assembly in :meth:`make_vprm_predictions`.
+        """
+        parameters = self.fit_params_dict[land_cover_type]
+        return (
+            land_cover_fraction
+            * (
+                parameters["lamb"]
+                * inputs["Ps"]
+                * inputs["Ws"]
+                * inputs["Ts"]
+                * inputs["evi"]
+                * inputs["par"]
+                / (1 + inputs["par"] / parameters["par0"])
+            )
+        )
+
+    def _calculate_respiration(self, land_cover_fraction, land_cover_type, inputs):
+        """Calculate base-VPRM ecosystem respiration for one class.
+
+        Parameters
+        ----------
+        land_cover_fraction : float, pandas.Series, or xarray.DataArray
+            Fractional coverage of ``land_cover_type`` on the prediction grid.
+        land_cover_type : int
+            VPRM class identifier whose fitted parameters are used.
+        inputs : dict
+            VPRM driver fields containing ``tcorr``, the air temperature in
+            degrees Celsius.
+
+        Returns
+        -------
+        float, pandas.Series, or xarray.DataArray
+            Non-negative ecosystem respiration for the requested VPRM class.
+
+        Notes
+        -----
+        UrbanVPRM overrides this hook to apply its ISA and reference-EVI
+        respiration adjustment.
+        """
+        parameters = self.fit_params_dict[land_cover_type]
+        return np.maximum(
+            land_cover_fraction
+            * (parameters["alpha"] * inputs["tcorr"] + parameters["beta"]),
+            0,
+        )
+
     def make_vprm_predictions(
         self,
         date=None,
@@ -445,28 +512,8 @@ class vprm_base_model:
                     return None
             else:
                 lcf = 1
-            gpps.append(
-                lcf
-                * (
-                    self.fit_params_dict[i]["lamb"]
-                    * inputs["Ps"]
-                    * inputs["Ws"]
-                    * inputs["Ts"]
-                    * inputs["evi"]
-                    * inputs["par"]
-                    / (1 + inputs["par"] / self.fit_params_dict[i]["par0"])
-                )
-            )
-            respirations.append(
-                np.maximum(
-                    lcf
-                    * (
-                        self.fit_params_dict[i]["alpha"] * inputs["tcorr"]
-                        + self.fit_params_dict[i]["beta"]
-                    ),
-                    0,
-                )
-            )
+            gpps.append(self._calculate_gpp(lcf, i, inputs))
+            respirations.append(self._calculate_respiration(lcf, i, inputs))
         if concatenate_fluxes:
             if isinstance(gpps[0], pd.core.series.Series):
                 ret_res["gpp"] = gpps[0]

--- a/pyVPRM/vprm_models/vprm_urban_model.py
+++ b/pyVPRM/vprm_models/vprm_urban_model.py
@@ -1,6 +1,7 @@
 """UrbanVPRM flux model using ISA, reference EVI, and UHI-adjusted temperature."""
 
 import numpy as np
+import scipy
 import xarray as xr
 
 from pyVPRM.vprm_models.vprm_base_model import vprm_base_model
@@ -25,6 +26,13 @@ class vprm_urban_model(vprm_base_model):
         Callable accepting ``(temperature, isa_fraction, datetime_utc)`` and
         returning UHI-adjusted air temperature in degrees Celsius. It is
         required when preparing drivers for an urban class.
+    reference_search_mode : {"dynamic_positive", "static"}, default="dynamic_positive"
+        Method for selecting ISA-zero vegetated EVI references. Dynamic mode
+        selects the nearest candidate with positive EVI for each satellite
+        composite and caches that result until the composite changes.
+    minimum_reference_evi : float, default=1e-6
+        Strict lower EVI bound for dynamic reference-cell selection and for
+        validating a reference EVI in the respiration calculation.
 
     Notes
     -----
@@ -40,6 +48,8 @@ class vprm_urban_model(vprm_base_model):
         fit_params_dict=None,
         urban_vprm_classes=(10, 11),
         uhi_temperature_adjustment=None,
+        reference_search_mode="dynamic_positive",
+        minimum_reference_evi=1e-6,
     ):
         """Initialize UrbanVPRM model state.
 
@@ -55,10 +65,20 @@ class vprm_urban_model(vprm_base_model):
             VPRM classes using UrbanVPRM adjustments.
         uhi_temperature_adjustment : callable, optional
             UHI temperature adjustment callable.
+        reference_search_mode : {"dynamic_positive", "static"}, default="dynamic_positive"
+            EVI reference selection method.
+        minimum_reference_evi : float, default=1e-6
+            Strict lower bound for usable reference EVI.
         """
         super().__init__(vprm_pre=vprm_pre, met=met, fit_params_dict=fit_params_dict)
         self.urban_vprm_classes = frozenset(urban_vprm_classes)
         self.uhi_temperature_adjustment = uhi_temperature_adjustment
+        if reference_search_mode not in {"dynamic_positive", "static"}:
+            raise ValueError(
+                "reference_search_mode must be 'dynamic_positive' or 'static'."
+            )
+        self.reference_search_mode = reference_search_mode
+        self.minimum_reference_evi = minimum_reference_evi
         self._isa_fraction_cache = None
         self._reference_minimum_evi_cache = None
         self._reference_current_evi_cache = None
@@ -116,7 +136,12 @@ class vprm_urban_model(vprm_base_model):
         return isa_fraction
 
     def _get_reference_evi(self):
-        """Gather current and annual-minimum EVI at local reference cells.
+        """Gather EVI at static or current-composite reference cells.
+
+        In ``dynamic_positive`` mode, a distance transform finds the nearest
+        ISA-zero vegetated candidate with finite positive EVI for the current
+        satellite composite. The resulting indices and both EVI fields are
+        cached until the satellite-composite counter changes.
 
         Returns
         -------
@@ -134,49 +159,77 @@ class vprm_urban_model(vprm_base_model):
             raise ValueError("UrbanVPRM requires a reference-EVI lookup.")
         lookup = self.vprm_pre.urban_reference_evi.sat_img
         current_counter = self.vprm_pre.counter
-        coordinate_free_y_index = None
-        coordinate_free_x_index = None
+        if (
+            getattr(self, "_reference_current_evi_cache", None) is not None
+            and getattr(self, "_reference_evi_counter_cache", None)
+            == current_counter
+        ):
+            return (
+                self._reference_current_evi_cache,
+                self._reference_minimum_evi_cache,
+            )
 
-        def get_coordinate_free_indices():
-            """Return target-grid reference indices without coordinate conflicts.
+        def coordinate_free_indices(y_index, x_index):
+            """Return index arrays without conflicting coordinate labels.
+
+            Parameters
+            ----------
+            y_index, x_index : xarray.DataArray
+                Reference-cell row and column index arrays.
 
             Returns
             -------
             tuple[xarray.DataArray, xarray.DataArray]
-                Coordinate-free y and x index arrays for vectorized indexing.
+                Coordinate-free row and column arrays for vectorized indexing.
             """
-
-            y_index = lookup["reference_y_index"]
-            x_index = lookup["reference_x_index"]
             return (
                 xr.DataArray(y_index.data, dims=y_index.dims),
                 xr.DataArray(x_index.data, dims=x_index.dims),
             )
 
-        if getattr(self, "_reference_minimum_evi_cache", None) is None:
-            coordinate_free_y_index, coordinate_free_x_index = (
-                get_coordinate_free_indices()
+        current_evi = self.vprm_pre.sat_imgs.sat_img["evi"].isel(
+            {self.vprm_pre.time_key: current_counter}
+        )
+        reference_search_mode = getattr(self, "reference_search_mode", "static")
+        minimum_reference_evi = getattr(self, "minimum_reference_evi", 1e-6)
+        if reference_search_mode == "dynamic_positive":
+            candidate_values = np.asarray(lookup["reference_eligible"].values, dtype=bool)
+            valid_reference = (
+                candidate_values
+                & np.isfinite(current_evi.values)
+                & (current_evi.values > minimum_reference_evi)
+            )
+            if valid_reference.any():
+                y_resolution = np.abs(np.diff(current_evi.y.values)).mean()
+                x_resolution = np.abs(np.diff(current_evi.x.values)).mean()
+                _, nearest_indices = scipy.ndimage.distance_transform_edt(
+                    ~valid_reference,
+                    sampling=(y_resolution, x_resolution),
+                    return_indices=True,
+                )
+                y_index = xr.DataArray(nearest_indices[0], dims=("y", "x"))
+                x_index = xr.DataArray(nearest_indices[1], dims=("y", "x"))
+            else:
+                y_index = x_index = None
+        else:
+            y_index = lookup["reference_y_index"]
+            x_index = lookup["reference_x_index"]
+
+        if y_index is None:
+            self._reference_current_evi_cache = xr.full_like(current_evi, np.nan)
+            self._reference_minimum_evi_cache = xr.full_like(current_evi, np.nan)
+        else:
+            coordinate_free_y_index, coordinate_free_x_index = coordinate_free_indices(
+                y_index, x_index
             )
             minimum_evi = self.vprm_pre.min_max_evi.sat_img["min_evi"]
-            self._reference_minimum_evi_cache = minimum_evi.isel(
-                y=coordinate_free_y_index, x=coordinate_free_x_index
-            ).assign_coords(y=lookup.coords["y"], x=lookup.coords["x"])
-
-        if (
-            getattr(self, "_reference_current_evi_cache", None) is None
-            or getattr(self, "_reference_evi_counter_cache", None) != current_counter
-        ):
-            if coordinate_free_y_index is None:
-                coordinate_free_y_index, coordinate_free_x_index = (
-                    get_coordinate_free_indices()
-                )
-            current_evi = self.vprm_pre.sat_imgs.sat_img["evi"].isel(
-                {self.vprm_pre.time_key: current_counter}
-            )
             self._reference_current_evi_cache = current_evi.isel(
                 y=coordinate_free_y_index, x=coordinate_free_x_index
             ).assign_coords(y=lookup.coords["y"], x=lookup.coords["x"])
-            self._reference_evi_counter_cache = current_counter
+            self._reference_minimum_evi_cache = minimum_evi.isel(
+                y=coordinate_free_y_index, x=coordinate_free_x_index
+            ).assign_coords(y=lookup.coords["y"], x=lookup.coords["x"])
+        self._reference_evi_counter_cache = current_counter
 
         return self._reference_current_evi_cache, self._reference_minimum_evi_cache
 
@@ -268,6 +321,12 @@ class vprm_urban_model(vprm_base_model):
         -------
         float, pandas.Series, or xarray.DataArray
             Ecosystem respiration for the requested class.
+
+        Notes
+        -----
+        A non-finite or non-positive reference EVI is not physically usable
+        for the UrbanVPRM autotrophic-respiration ratio. It therefore yields
+        missing respiration rather than an arbitrarily large value.
         """
         if land_cover_type not in self.urban_vprm_classes:
             return super()._calculate_respiration(
@@ -286,7 +345,10 @@ class vprm_urban_model(vprm_base_model):
             land_cover_fraction, land_cover_type, inputs
         )
         heterotrophic_respiration = (1.0 - inputs["ISA"]) * re_initial / 2.0
-        reference_evi = np.maximum(inputs["evi_ref"], 1e-6)
+        reference_evi = inputs["evi_ref"].where(
+            np.isfinite(inputs["evi_ref"])
+            & (inputs["evi_ref"] > getattr(self, "minimum_reference_evi", 1e-6))
+        )
         autotrophic_respiration = (
             (inputs["evi"] + inputs["min_evi_ref"] * inputs["ISA"])
             / reference_evi

--- a/pyVPRM/vprm_models/vprm_urban_model.py
+++ b/pyVPRM/vprm_models/vprm_urban_model.py
@@ -1,37 +1,130 @@
-from vprm_base_model import vprm_base_model
-from loguru import logger
+"""UrbanVPRM flux model using ISA, reference EVI, and UHI-adjusted temperature."""
+
+import numpy as np
+
+from pyVPRM.vprm_models.vprm_base_model import vprm_base_model
 
 
 class vprm_urban_model(vprm_base_model):
+    """Apply UrbanVPRM adjustments to selected VPRM land-cover classes.
+
+    Parameters
+    ----------
+    vprm_pre : urban_vprm_preprocessor
+        Preprocessor containing regridded impervious surface area and the
+        static nearest-reference EVI lookup.
+    met : object
+        Meteorology handler accepted by :class:`vprm_base_model`.
+    fit_params_dict : dict
+        Per-VPRM-class fitted flux parameters.
+    urban_vprm_classes : iterable of int, default=(10, 11)
+        VPRM classes to which UrbanVPRM adjustments apply. Other classes use
+        the unchanged base-VPRM temperature and respiration calculations.
+    uhi_temperature_adjustment : callable, optional
+        Callable accepting ``(temperature, isa_fraction, datetime_utc)`` and
+        returning UHI-adjusted air temperature in degrees Celsius. It is
+        required when preparing drivers for an urban class.
+
+    Notes
+    -----
+    Respiration follows Hardiman et al. (2017) Supplement Eqs. 6--8. The
+    caller supplies the UHI parameterization because its coefficients are
+    location- and time-specific.
     """
-    implemement urbanVPRM (Hardiman et al. 2017, Winbourne et al 2021)
 
-    compared to the VPRM base model, urbanVPRM:
-    - adjusts the temperature to account for urban heat island effect
-    - adjusts respiration according to impervious surface area
-    REFERENCES
+    def __init__(
+        self,
+        vprm_pre=None,
+        met=None,
+        fit_params_dict=None,
+        urban_vprm_classes=(10, 11),
+        uhi_temperature_adjustment=None,
+    ):
+        """Initialize UrbanVPRM model state.
 
-    Hardiman, B. S., Wang, J. A., Hutyra, L. R., Gately, C. K., Getson, J. M., &
-    Friedl, M. A. (2017). Accounting for urban biogenic fluxes in regional
-    carbon budgets. Science of The Total Environment, 592, 366–372.
-    https://doi.org/10.1016/j.scitotenv.2017.03.028
+        Parameters
+        ----------
+        vprm_pre : urban_vprm_preprocessor
+            Preprocessor containing UrbanVPRM ancillary fields.
+        met : object
+            Meteorology handler accepted by :class:`vprm_base_model`.
+        fit_params_dict : dict
+            Per-VPRM-class fitted flux parameters.
+        urban_vprm_classes : iterable of int, default=(10, 11)
+            VPRM classes using UrbanVPRM adjustments.
+        uhi_temperature_adjustment : callable, optional
+            UHI temperature adjustment callable.
+        """
+        super().__init__(vprm_pre=vprm_pre, met=met, fit_params_dict=fit_params_dict)
+        self.urban_vprm_classes = frozenset(urban_vprm_classes)
+        self.uhi_temperature_adjustment = uhi_temperature_adjustment
 
-    Winbourne, J. B., Smith, I. A., Stoynova, H., Kohler, C., Gately, C. K.,
-    Logan, B. A., et al. (2022). Quantification of urban forest and grassland
-    carbon fluxes using field measurements and a satellite-based model in
-    Washington DC/Baltimore area. Journal of Geophysical Research:
-    Biogeosciences, 127(1), e2021JG006568. https://doi.org/10.1029/2021JG006568
+    def get_isa_fraction(self, lon=None, lat=None):
+        """Return impervious-surface area as a fraction from zero to one.
 
-    """
+        Parameters
+        ----------
+        lon, lat : float, optional
+            Geographic query location. Omit both to return the complete
+            satellite-grid ISA field.
 
-    def __init__(self, vprm_pre=None, met=None, fit_params_dict=None):
-        super().__init__(vprm_pre, met, fit_params_dict)
-        return
+        Returns
+        -------
+        float or xarray.DataArray
+            Impervious-surface fraction on the requested support.
 
-    def get_ISA(self):
-        return self.vprm_pre.impervious_surface_area[
-            "impervious_surface_area_percentage"
-        ]
+        Raises
+        ------
+        ValueError
+            If the preprocessor lacks percent impervious-surface data or its
+            values are outside the expected zero-to-100 range.
+        """
+        if self.vprm_pre.impervious_surface_area is None:
+            raise ValueError("UrbanVPRM requires impervious-surface data.")
+        manager = self.vprm_pre.impervious_surface_area
+        variable_name = "impervious_surface_percentage"
+        if variable_name not in manager.sat_img:
+            raise ValueError(
+                "Impervious-surface data do not contain {!r}.".format(variable_name)
+            )
+        if lon is None:
+            isa_percent = manager.sat_img[variable_name]
+        else:
+            isa_percent = manager.value_at_lonlat(
+                lon, lat, key=variable_name, as_array=False
+            )
+        if np.nanmin(isa_percent) < 0 or np.nanmax(isa_percent) > 100:
+            raise ValueError("Impervious-surface percentages must be within 0--100.")
+        return isa_percent / 100.0
+
+    def _get_reference_evi(self):
+        """Gather current and annual-minimum EVI at local reference cells.
+
+        Returns
+        -------
+        tuple[xarray.DataArray, xarray.DataArray]
+            Current reference EVI and annual minimum reference EVI on the
+            target satellite grid.
+
+        Raises
+        ------
+        ValueError
+            If the UrbanVPRM preprocessor has not built its reference-EVI
+            lookup.
+        """
+        if getattr(self.vprm_pre, "urban_reference_evi", None) is None:
+            raise ValueError("UrbanVPRM requires a reference-EVI lookup.")
+        lookup = self.vprm_pre.urban_reference_evi.sat_img
+        y_index = lookup["reference_y_index"]
+        x_index = lookup["reference_x_index"]
+        current_evi = self.vprm_pre.sat_imgs.sat_img["evi"].isel(
+            {self.vprm_pre.time_key: self.vprm_pre.counter}
+        )
+        minimum_evi = self.vprm_pre.min_max_evi.sat_img["min_evi"]
+        return (
+            current_evi.isel(y=y_index, x=x_index),
+            minimum_evi.isel(y=y_index, x=x_index),
+        )
 
     def _get_vprm_variables(
         self,
@@ -42,33 +135,108 @@ class vprm_urban_model(vprm_base_model):
         add_era_variables=[],
         regridder_weights=None,
     ):
-        ret_dict = super()._get_vprm_variables(
-            land_cover_type,
-            datetime_utc,
-            lat,
-            lon,
-            add_era_variables,
-            regridder_weights,
-        )
+        """Get VPRM drivers, adding UrbanVPRM fields for urban classes.
 
-        logger.warning("T_UHI not yet implemented.  using Ts for T_UHI")
-        ret_dict["T_UHI"] = ret_dict["Ts"]
+        Parameters
+        ----------
+        land_cover_type : int
+            VPRM class identifier to prepare.
+        datetime_utc : datetime.datetime
+            Driver timestamp.
+        lat, lon : float, optional
+            Geographic query location. Urban reference-EVI gathering currently
+            requires gridded operation, so urban point-mode use is unsupported.
+        add_era_variables : list, optional
+            Additional ERA variables passed to the base model.
+        regridder_weights : str, optional
+            Precomputed meteorology regridding weights.
 
-        ret_dict["ISA"] = self.get_ISA()
-
-        return ret_dict
-
-    def get_respiration(self):
-        """calculate respiration
-
-        Calculate respiration according to Hardiman et al (2017) supplmemental material SI eqs. 6, 7, 8
+        Returns
+        -------
+        dict or None
+            Base VPRM drivers, plus ISA, reference EVI, and UHI-adjusted
+            temperature drivers for urban classes.
         """
-
-        Re_init = np.maximum(
-            lcf
-            * (
-                self.fit_params_dict[i]["alpha"] * inputs["tcorr"]
-                + self.fit_params_dict[i]["beta"]
-            ),
-            0,
+        inputs = super()._get_vprm_variables(
+            land_cover_type,
+            datetime_utc=datetime_utc,
+            lat=lat,
+            lon=lon,
+            add_era_variables=add_era_variables,
+            regridder_weights=regridder_weights,
         )
+        if inputs is None or land_cover_type not in self.urban_vprm_classes:
+            return inputs
+        if lon is not None:
+            raise ValueError("UrbanVPRM reference EVI currently requires gridded mode.")
+        if self.uhi_temperature_adjustment is None:
+            raise ValueError(
+                "UrbanVPRM requires a uhi_temperature_adjustment callable."
+            )
+
+        isa_fraction = self.get_isa_fraction()
+        uhi_temperature = self.uhi_temperature_adjustment(
+            inputs["tcorr"], isa_fraction, datetime_utc
+        )
+        temperature_scale = self.get_t_scale(
+            lon=lon,
+            lat=lat,
+            land_cover_type=land_cover_type,
+            temperature=uhi_temperature,
+        )
+        evi_ref, min_evi_ref = self._get_reference_evi()
+        inputs.update(
+            {
+                "ISA": isa_fraction,
+                "T_UHI": uhi_temperature,
+                "tcorr": temperature_scale[0],
+                "Ts": temperature_scale[1],
+                "evi_ref": evi_ref,
+                "min_evi_ref": min_evi_ref,
+            }
+        )
+        return inputs
+
+    def _calculate_respiration(self, land_cover_fraction, land_cover_type, inputs):
+        """Calculate base or Hardiman UrbanVPRM ecosystem respiration.
+
+        Parameters
+        ----------
+        land_cover_fraction : float, pandas.Series, or xarray.DataArray
+            Fractional coverage of the requested class.
+        land_cover_type : int
+            VPRM class identifier to calculate.
+        inputs : dict
+            VPRM drivers. Urban classes additionally require ``ISA``,
+            ``evi_ref``, and ``min_evi_ref``.
+
+        Returns
+        -------
+        float, pandas.Series, or xarray.DataArray
+            Ecosystem respiration for the requested class.
+        """
+        if land_cover_type not in self.urban_vprm_classes:
+            return super()._calculate_respiration(
+                land_cover_fraction, land_cover_type, inputs
+            )
+        required_keys = {"ISA", "evi", "evi_ref", "min_evi_ref"}
+        missing_keys = required_keys.difference(inputs)
+        if missing_keys:
+            raise ValueError(
+                "UrbanVPRM respiration requires inputs: {}.".format(
+                    ", ".join(sorted(missing_keys))
+                )
+            )
+
+        re_initial = super()._calculate_respiration(
+            land_cover_fraction, land_cover_type, inputs
+        )
+        heterotrophic_respiration = (1.0 - inputs["ISA"]) * re_initial / 2.0
+        reference_evi = np.maximum(inputs["evi_ref"], 1e-6)
+        autotrophic_respiration = (
+            (inputs["evi"] + inputs["min_evi_ref"] * inputs["ISA"])
+            / reference_evi
+            * re_initial
+            / 2.0
+        )
+        return heterotrophic_respiration + autotrophic_respiration

--- a/pyVPRM/vprm_models/vprm_urban_model.py
+++ b/pyVPRM/vprm_models/vprm_urban_model.py
@@ -1,0 +1,74 @@
+from vprm_base_model import vprm_base_model
+from loguru import logger
+
+
+class vprm_urban_model(vprm_base_model):
+    """
+    implemement urbanVPRM (Hardiman et al. 2017, Winbourne et al 2021)
+
+    compared to the VPRM base model, urbanVPRM:
+    - adjusts the temperature to account for urban heat island effect
+    - adjusts respiration according to impervious surface area
+    REFERENCES
+
+    Hardiman, B. S., Wang, J. A., Hutyra, L. R., Gately, C. K., Getson, J. M., &
+    Friedl, M. A. (2017). Accounting for urban biogenic fluxes in regional
+    carbon budgets. Science of The Total Environment, 592, 366–372.
+    https://doi.org/10.1016/j.scitotenv.2017.03.028
+
+    Winbourne, J. B., Smith, I. A., Stoynova, H., Kohler, C., Gately, C. K.,
+    Logan, B. A., et al. (2022). Quantification of urban forest and grassland
+    carbon fluxes using field measurements and a satellite-based model in
+    Washington DC/Baltimore area. Journal of Geophysical Research:
+    Biogeosciences, 127(1), e2021JG006568. https://doi.org/10.1029/2021JG006568
+
+    """
+
+    def __init__(self, vprm_pre=None, met=None, fit_params_dict=None):
+        super().__init__(vprm_pre, met, fit_params_dict)
+        return
+
+    def get_ISA(self):
+        return self.vprm_pre.impervious_surface_area[
+            "impervious_surface_area_percentage"
+        ]
+
+    def _get_vprm_variables(
+        self,
+        land_cover_type,
+        datetime_utc=None,
+        lat=None,
+        lon=None,
+        add_era_variables=[],
+        regridder_weights=None,
+    ):
+        ret_dict = super()._get_vprm_variables(
+            land_cover_type,
+            datetime_utc,
+            lat,
+            lon,
+            add_era_variables,
+            regridder_weights,
+        )
+
+        logger.warning("T_UHI not yet implemented.  using Ts for T_UHI")
+        ret_dict["T_UHI"] = ret_dict["Ts"]
+
+        ret_dict["ISA"] = self.get_ISA()
+
+        return ret_dict
+
+    def get_respiration(self):
+        """calculate respiration
+
+        Calculate respiration according to Hardiman et al (2017) supplmemental material SI eqs. 6, 7, 8
+        """
+
+        Re_init = np.maximum(
+            lcf
+            * (
+                self.fit_params_dict[i]["alpha"] * inputs["tcorr"]
+                + self.fit_params_dict[i]["beta"]
+            ),
+            0,
+        )

--- a/pyVPRM/vprm_models/vprm_urban_model.py
+++ b/pyVPRM/vprm_models/vprm_urban_model.py
@@ -1,6 +1,7 @@
 """UrbanVPRM flux model using ISA, reference EVI, and UHI-adjusted temperature."""
 
 import numpy as np
+import xarray as xr
 
 from pyVPRM.vprm_models.vprm_base_model import vprm_base_model
 
@@ -58,6 +59,10 @@ class vprm_urban_model(vprm_base_model):
         super().__init__(vprm_pre=vprm_pre, met=met, fit_params_dict=fit_params_dict)
         self.urban_vprm_classes = frozenset(urban_vprm_classes)
         self.uhi_temperature_adjustment = uhi_temperature_adjustment
+        self._isa_fraction_cache = None
+        self._reference_minimum_evi_cache = None
+        self._reference_current_evi_cache = None
+        self._reference_evi_counter_cache = None
 
     def get_isa_fraction(self, lon=None, lat=None):
         """Return impervious-surface area as a fraction from zero to one.
@@ -81,6 +86,8 @@ class vprm_urban_model(vprm_base_model):
         """
         if self.vprm_pre.impervious_surface_area is None:
             raise ValueError("UrbanVPRM requires impervious-surface data.")
+        if lon is None and getattr(self, "_isa_fraction_cache", None) is not None:
+            return self._isa_fraction_cache
         manager = self.vprm_pre.impervious_surface_area
         variable_name = "impervious_surface_percentage"
         if variable_name not in manager.sat_img:
@@ -93,9 +100,20 @@ class vprm_urban_model(vprm_base_model):
             isa_percent = manager.value_at_lonlat(
                 lon, lat, key=variable_name, as_array=False
             )
-        if np.nanmin(isa_percent) < 0 or np.nanmax(isa_percent) > 100:
-            raise ValueError("Impervious-surface percentages must be within 0--100.")
-        return isa_percent / 100.0
+        tolerance = 1e-6
+        minimum_percent = float(np.nanmin(isa_percent))
+        maximum_percent = float(np.nanmax(isa_percent))
+        if minimum_percent < -tolerance or maximum_percent > 100 + tolerance:
+            raise ValueError(
+                "Impervious-surface percentages must be within 0--100; got "
+                "minimum {:.12g} and maximum {:.12g}.".format(
+                    minimum_percent, maximum_percent
+                )
+            )
+        isa_fraction = np.clip(isa_percent, 0.0, 100.0) / 100.0
+        if lon is None:
+            self._isa_fraction_cache = isa_fraction
+        return isa_fraction
 
     def _get_reference_evi(self):
         """Gather current and annual-minimum EVI at local reference cells.
@@ -115,16 +133,52 @@ class vprm_urban_model(vprm_base_model):
         if getattr(self.vprm_pre, "urban_reference_evi", None) is None:
             raise ValueError("UrbanVPRM requires a reference-EVI lookup.")
         lookup = self.vprm_pre.urban_reference_evi.sat_img
-        y_index = lookup["reference_y_index"]
-        x_index = lookup["reference_x_index"]
-        current_evi = self.vprm_pre.sat_imgs.sat_img["evi"].isel(
-            {self.vprm_pre.time_key: self.vprm_pre.counter}
-        )
-        minimum_evi = self.vprm_pre.min_max_evi.sat_img["min_evi"]
-        return (
-            current_evi.isel(y=y_index, x=x_index),
-            minimum_evi.isel(y=y_index, x=x_index),
-        )
+        current_counter = self.vprm_pre.counter
+        coordinate_free_y_index = None
+        coordinate_free_x_index = None
+
+        def get_coordinate_free_indices():
+            """Return target-grid reference indices without coordinate conflicts.
+
+            Returns
+            -------
+            tuple[xarray.DataArray, xarray.DataArray]
+                Coordinate-free y and x index arrays for vectorized indexing.
+            """
+
+            y_index = lookup["reference_y_index"]
+            x_index = lookup["reference_x_index"]
+            return (
+                xr.DataArray(y_index.data, dims=y_index.dims),
+                xr.DataArray(x_index.data, dims=x_index.dims),
+            )
+
+        if getattr(self, "_reference_minimum_evi_cache", None) is None:
+            coordinate_free_y_index, coordinate_free_x_index = (
+                get_coordinate_free_indices()
+            )
+            minimum_evi = self.vprm_pre.min_max_evi.sat_img["min_evi"]
+            self._reference_minimum_evi_cache = minimum_evi.isel(
+                y=coordinate_free_y_index, x=coordinate_free_x_index
+            ).assign_coords(y=lookup.coords["y"], x=lookup.coords["x"])
+
+        if (
+            getattr(self, "_reference_current_evi_cache", None) is None
+            or getattr(self, "_reference_evi_counter_cache", None) != current_counter
+        ):
+            if coordinate_free_y_index is None:
+                coordinate_free_y_index, coordinate_free_x_index = (
+                    get_coordinate_free_indices()
+                )
+            current_evi = self.vprm_pre.sat_imgs.sat_img["evi"].isel(
+                {self.vprm_pre.time_key: current_counter}
+            )
+            self._reference_current_evi_cache = current_evi.isel(
+                y=coordinate_free_y_index, x=coordinate_free_x_index
+            ).assign_coords(y=lookup.coords["y"], x=lookup.coords["x"])
+            self._reference_evi_counter_cache = current_counter
+
+        return self._reference_current_evi_cache, self._reference_minimum_evi_cache
 
     def _get_vprm_variables(
         self,

--- a/tests/test_vprm_model_hooks.py
+++ b/tests/test_vprm_model_hooks.py
@@ -1,0 +1,48 @@
+"""Tests for overridable base-VPRM flux calculation hooks."""
+
+import numpy as np
+import xarray as xr
+
+from pyVPRM.vprm_models.vprm_base_model import vprm_base_model
+
+
+def test_base_model_flux_hooks_preserve_current_equations():
+    """Match the original base-VPRM GPP and respiration calculations.
+
+    Returns
+    -------
+    None
+        The test confirms that extracted flux hooks preserve the former inline
+        equations for a two-cell xarray input.
+    """
+    model = object.__new__(vprm_base_model)
+    model.fit_params_dict = {
+        3: {"lamb": 0.5, "par0": 1000.0, "alpha": 0.2, "beta": -1.0}
+    }
+    land_cover_fraction = xr.DataArray([0.25, 1.0], dims="x")
+    inputs = {
+        "Ps": xr.DataArray([0.5, 1.0], dims="x"),
+        "Ws": xr.DataArray([0.8, 0.6], dims="x"),
+        "Ts": xr.DataArray([0.9, 0.7], dims="x"),
+        "evi": xr.DataArray([0.3, 0.4], dims="x"),
+        "par": xr.DataArray([500.0, 1000.0], dims="x"),
+        "tcorr": xr.DataArray([2.0, 10.0], dims="x"),
+    }
+
+    gpp = model._calculate_gpp(land_cover_fraction, 3, inputs)
+    respiration = model._calculate_respiration(land_cover_fraction, 3, inputs)
+
+    expected_gpp = land_cover_fraction * (
+        0.5
+        * inputs["Ps"]
+        * inputs["Ws"]
+        * inputs["Ts"]
+        * inputs["evi"]
+        * inputs["par"]
+        / (1 + inputs["par"] / 1000.0)
+    )
+    expected_respiration = np.maximum(
+        land_cover_fraction * (0.2 * inputs["tcorr"] - 1.0), 0
+    )
+    xr.testing.assert_identical(gpp, expected_gpp)
+    xr.testing.assert_identical(respiration, expected_respiration)

--- a/tests/test_vprm_urban_model.py
+++ b/tests/test_vprm_urban_model.py
@@ -1,0 +1,40 @@
+"""Tests for Hardiman-style UrbanVPRM respiration adjustments."""
+
+import numpy as np
+import xarray as xr
+
+from pyVPRM.vprm_models.vprm_urban_model import vprm_urban_model
+
+
+def test_urban_respiration_uses_isa_and_reference_evi():
+    """Apply Hardiman Supplement Eqs. 6--8 to an urban class.
+
+    Returns
+    -------
+    None
+        The test verifies urban heterotrophic and autotrophic respiration and
+        confirms non-urban classes retain base-VPRM respiration.
+    """
+    model = object.__new__(vprm_urban_model)
+    model.urban_vprm_classes = frozenset({10, 11})
+    model.fit_params_dict = {
+        3: {"alpha": 0.2, "beta": -1.0},
+        10: {"alpha": 0.2, "beta": -1.0},
+    }
+    inputs = {
+        "tcorr": xr.DataArray([10.0]),
+        "evi": xr.DataArray([0.3]),
+        "ISA": xr.DataArray([0.4]),
+        "evi_ref": xr.DataArray([0.5]),
+        "min_evi_ref": xr.DataArray([0.1]),
+    }
+
+    urban_respiration = model._calculate_respiration(1.0, 10, inputs)
+    non_urban_respiration = model._calculate_respiration(1.0, 3, inputs)
+
+    re_initial = 1.0
+    expected_urban = (1.0 - 0.4) * re_initial / 2.0 + (
+        (0.3 + 0.1 * 0.4) / 0.5 * re_initial / 2.0
+    )
+    xr.testing.assert_allclose(urban_respiration, xr.DataArray([expected_urban]))
+    xr.testing.assert_allclose(non_urban_respiration, xr.DataArray([re_initial]))

--- a/tests/test_vprm_urban_model.py
+++ b/tests/test_vprm_urban_model.py
@@ -1,8 +1,10 @@
 """Tests for Hardiman-style UrbanVPRM respiration adjustments."""
 
 import numpy as np
+import pytest
 import xarray as xr
 
+from pyVPRM.sat_managers.base_manager import satellite_data_manager
 from pyVPRM.vprm_models.vprm_urban_model import vprm_urban_model
 
 
@@ -38,3 +40,128 @@ def test_urban_respiration_uses_isa_and_reference_evi():
     )
     xr.testing.assert_allclose(urban_respiration, xr.DataArray([expected_urban]))
     xr.testing.assert_allclose(non_urban_respiration, xr.DataArray([re_initial]))
+
+
+def test_isa_fraction_clips_numerical_bound_overshoots():
+    """Clip negligible percentage-bound overshoots before ISA conversion.
+
+    Returns
+    -------
+    None
+        The test verifies that conservative-regridding roundoff at zero and
+        100 percent is clipped, while a material out-of-range value fails.
+    """
+    model = object.__new__(vprm_urban_model)
+    model.vprm_pre = type("Preprocessor", (), {})()
+    model.vprm_pre.impervious_surface_area = satellite_data_manager(
+        sat_img=xr.Dataset(
+            {
+                "impervious_surface_percentage": xr.DataArray(
+                    [[-1e-9, 100.0 + 1e-9]], dims=("y", "x")
+                )
+            }
+        )
+    )
+
+    isa_fraction = model.get_isa_fraction()
+    xr.testing.assert_allclose(
+        isa_fraction, xr.DataArray([[0.0, 1.0]], dims=("y", "x"))
+    )
+
+    model.vprm_pre.impervious_surface_area.sat_img[
+        "impervious_surface_percentage"
+    ].data[0, 1] = 100.1
+    model._isa_fraction_cache = None
+    with pytest.raises(ValueError, match="maximum 100.1"):
+        model.get_isa_fraction()
+
+
+def test_reference_evi_lookup_uses_target_grid_coordinates():
+    """Gather reference EVI without retaining source-grid index coordinates.
+
+    Returns
+    -------
+    None
+        The test verifies that two-dimensional reference indexers carrying
+        target-grid coordinates produce target-grid reference EVI fields.
+    """
+    source_y = [10.0, 20.0]
+    source_x = [30.0, 40.0]
+    target_y = [100.0, 200.0]
+    target_x = [300.0, 400.0]
+    evi = xr.DataArray(
+        [
+            [[0.1, 0.2], [0.3, 0.4]],
+            [[0.5, 0.6], [0.7, 0.8]],
+        ],
+        dims=("time", "y", "x"),
+        coords={"time": [0, 1], "y": source_y, "x": source_x},
+    )
+    min_evi = xr.DataArray(
+        [[0.01, 0.02], [0.03, 0.04]],
+        dims=("y", "x"),
+        coords={"y": source_y, "x": source_x},
+    )
+    lookup = xr.Dataset(
+        {
+            "reference_y_index": xr.DataArray(
+                [[1, 0], [0, 1]],
+                dims=("y", "x"),
+                coords={"y": target_y, "x": target_x},
+            ),
+            "reference_x_index": xr.DataArray(
+                [[1, 0], [1, 0]],
+                dims=("y", "x"),
+                coords={"y": target_y, "x": target_x},
+            ),
+        }
+    )
+    model = object.__new__(vprm_urban_model)
+    model.vprm_pre = type("Preprocessor", (), {})()
+    model.vprm_pre.time_key = "time"
+    model.vprm_pre.counter = 0
+    model.vprm_pre.sat_imgs = satellite_data_manager(
+        sat_img=evi.to_dataset(name="evi")
+    )
+    model.vprm_pre.min_max_evi = satellite_data_manager(
+        sat_img=min_evi.to_dataset(name="min_evi")
+    )
+    model.vprm_pre.urban_reference_evi = satellite_data_manager(sat_img=lookup)
+
+    reference_evi, minimum_reference_evi = model._get_reference_evi()
+
+    xr.testing.assert_allclose(
+        reference_evi,
+        xr.DataArray(
+            [[0.4, 0.1], [0.2, 0.3]],
+            dims=("y", "x"),
+            coords={"time": 0, "y": target_y, "x": target_x},
+        ),
+    )
+    xr.testing.assert_allclose(
+        minimum_reference_evi,
+        xr.DataArray(
+            [[0.04, 0.01], [0.02, 0.03]],
+            dims=("y", "x"),
+            coords={"y": target_y, "x": target_x},
+        ),
+    )
+
+    model.vprm_pre.sat_imgs.sat_img["evi"].data[0, :, :] = 99.0
+    cached_reference_evi, cached_minimum_reference_evi = model._get_reference_evi()
+    xr.testing.assert_allclose(cached_reference_evi, reference_evi)
+    xr.testing.assert_allclose(cached_minimum_reference_evi, minimum_reference_evi)
+
+    model.vprm_pre.counter = 1
+    refreshed_reference_evi, refreshed_minimum_reference_evi = (
+        model._get_reference_evi()
+    )
+    xr.testing.assert_allclose(
+        refreshed_reference_evi,
+        xr.DataArray(
+            [[0.8, 0.5], [0.6, 0.7]],
+            dims=("y", "x"),
+            coords={"time": 1, "y": target_y, "x": target_x},
+        ),
+    )
+    xr.testing.assert_allclose(refreshed_minimum_reference_evi, minimum_reference_evi)

--- a/tests/test_vprm_urban_model.py
+++ b/tests/test_vprm_urban_model.py
@@ -165,3 +165,62 @@ def test_reference_evi_lookup_uses_target_grid_coordinates():
         ),
     )
     xr.testing.assert_allclose(refreshed_minimum_reference_evi, minimum_reference_evi)
+
+
+def test_dynamic_reference_evi_search_uses_positive_current_evi():
+    """Select the nearest currently positive EVI reference per composite.
+
+    Returns
+    -------
+    None
+        The test verifies that the cached dynamic search changes reference
+        cells only when the satellite-composite counter changes.
+    """
+    evi = xr.DataArray(
+        [
+            [[0.0, 0.5], [0.0, 0.0]],
+            [[0.6, 0.0], [0.0, 0.0]],
+        ],
+        dims=("time", "y", "x"),
+        coords={"time": [0, 1], "y": [10.0, 20.0], "x": [30.0, 40.0]},
+    )
+    lookup = xr.Dataset(
+        {
+            "reference_y_index": xr.DataArray(
+                [[0, 0], [0, 0]],
+                dims=("y", "x"),
+                coords={"y": evi.y, "x": evi.x},
+            ),
+            "reference_x_index": xr.DataArray(
+                [[0, 0], [0, 0]],
+                dims=("y", "x"),
+                coords={"y": evi.y, "x": evi.x},
+            ),
+            "reference_eligible": xr.DataArray(
+                [[True, True], [True, True]],
+                dims=("y", "x"),
+                coords={"y": evi.y, "x": evi.x},
+            ),
+        }
+    )
+    model = object.__new__(vprm_urban_model)
+    model.reference_search_mode = "dynamic_positive"
+    model.minimum_reference_evi = 1e-6
+    model._reference_current_evi_cache = None
+    model._reference_minimum_evi_cache = None
+    model._reference_evi_counter_cache = None
+    model.vprm_pre = type("Preprocessor", (), {})()
+    model.vprm_pre.time_key = "time"
+    model.vprm_pre.counter = 0
+    model.vprm_pre.sat_imgs = satellite_data_manager(sat_img=evi.to_dataset(name="evi"))
+    model.vprm_pre.min_max_evi = satellite_data_manager(
+        sat_img=evi.min("time").to_dataset(name="min_evi")
+    )
+    model.vprm_pre.urban_reference_evi = satellite_data_manager(sat_img=lookup)
+
+    first_reference, _ = model._get_reference_evi()
+    xr.testing.assert_allclose(first_reference, xr.full_like(evi.isel(time=0), 0.5))
+
+    model.vprm_pre.counter = 1
+    second_reference, _ = model._get_reference_evi()
+    xr.testing.assert_allclose(second_reference, xr.full_like(evi.isel(time=1), 0.6))


### PR DESCRIPTION
# Add UrbanVPRM model and reference-EVI preprocessing

## Summary

Add an initial UrbanVPRM extension of the standard VPRM model. It applies the impervious-surface-area (ISA), reference-EVI respiration treatment, and UHI-adjusted temperature drivers from [Hardiman et al. (2017)](https://doi.org/10.1016/j.scitotenv.2017.03.028), while preserving ordinary VPRM calculations for every non-urban class.

## Design

### Base-model extension points

The base model now exposes protected GPP and respiration calculation hooks. The existing classwise loop and output assembly remain in the base model. This lets an extension override only the class-specific flux calculation it needs, without duplicating the VPRM prediction workflow.

### Urban preprocessing

`urban_vprm_preprocessor(vprm_preprocessor)` builds a static reference EVI lookup for each satellite-grid cell:

- eligible reference cells are ISA-zero cells with fractional coverage of a caller-selected vegetated VPRM class;
- water and non-vegetated classes can therefore be excluded explicitly;
- the lookup stores nearest-reference row/column indices, distance, the eligibility mask, and available annual EVI extrema.

ISA itself is supplied on the satellite grid by a compatible preprocessing step. The separate GISA-new PR #41  provides one such workflow; this PR does not tie UrbanVPRM to a particular ISA product.

### Urban flux model

`vprm_urban_model(vprm_base_model)`:

- applies UrbanVPRM only to explicitly configured urban classes (default 10 and 11);
- retains unmodified base-VPRM GPP and respiration for all other classes;
- accepts a caller-supplied UHI temperature-adjustment callable, rather than embedding region-specific UHI coefficients;
- implements [Hardiman et al. (2017)](https://doi.org/10.1016/j.scitotenv.2017.03.028) Appendix A Supplement SI Eqs. 6--8 for urban respiration;
- converts ISA percentages to a validated 0--1 fraction, allowing only tiny conservative-regridding roundoff beyond the 0--100 percent bounds.

By default, dynamic EVI reference selection finds the nearest eligible cell with finite positive EVI for the current satellite image. The result is cached until the image changes. This avoids using an ISA-zero reference whose EVI is currently cloud-masked or zero while avoiding repeated work for every modelled hour in the same satellite image.

## Example

```python
urban_pre = urban_vprm_preprocessor(...)
# Attach ISA using a compatible preprocessing workflow.
urban_pre.add_urban_reference_evi_lookup(
    vegetated_vprm_classes=[3, 4, 6, 7, 9],
)

model = vprm_urban_model(
    vprm_pre=urban_pre,
    met=meteorology,
    fit_params_dict=parameters,
    urban_vprm_classes=(10, 11),
    uhi_temperature_adjustment=lambda temperature, isa, when: temperature,
)
```

The identity callable in this example represents an explicit zero-UHI assumption; applications should provide a suitable local parameterization when one is available.

## Validation

- Tests confirm the extracted base-model hooks reproduce the former VPRM GPP and respiration equations.
- UrbanVPRM tests cover the Hardiman ISA/reference-EVI respiration equations, ISA percentage validation, static lookup indexing, dynamic positive-EVI reference selection and cache refresh, and preservation of base behavior for non-urban classes.
- Focused test suite on this branch: `5 passed`.
